### PR TITLE
GOVSI-457: tweak legal and policy scenarios for research round 5 flow

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LegalAndPolicyPagesStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LegalAndPolicyPagesStepDefinitions.java
@@ -45,7 +45,7 @@ public class LegalAndPolicyPagesStepDefinitions extends SignInStepDefinitions {
     @Then("the user is taken to the Identity Provider Login Page")
     public void theExistingUserIsTakenToTheIdentityProviderLoginPage() {
         waitForPageLoad("Sign in or create a GOV.UK account");
-        assertEquals("/enter-email", URI.create(driver.getCurrentUrl()).getPath());
+        assertEquals("/sign-in-or-create", URI.create(driver.getCurrentUrl()).getPath());
         assertEquals(IDP_URL.getHost(), URI.create(driver.getCurrentUrl()).getHost());
         assertEquals("Sign in or create a GOV.UK account - GOV.UK Account", driver.getTitle());
     }


### PR DESCRIPTION
## What?

Tweak legal and policy scenarios for research round 5 flow.
Update IDP landing page from 'enter-email' to 'sign-in-or-create'

## Why?

IDP landing page was pointing to the old landing page.

## Related PRs

#7 
