### PR TITLE
BAU: set selenium image version to the one used by local

### DIFF
--- a/nginx/manifest.yml
+++ b/nginx/manifest.yml
@@ -18,5 +18,5 @@ applications:
   - name: selenium-build
     disk_quota: 2G
     docker:
-      image: selenium/standalone-firefox@sha256:861b3b47803aa87009de4bc34c1625cfa35e18cda63b5dd8843189787abaa9ba
+      image: selenium/standalone-firefox@sha256:4cee1e9d02dc0ff00683582a678a904991016a4534fa61bda2db11982d5094f4
       username: ((docker-hub-username))


### PR DESCRIPTION
## What?

Set selenium image version to the one used by local

## Why?

Latest versions are not running in Concourse.

## Related PRs

#27 
#26 
