### PR TITLE
Use smart quotes in account confirmation copy

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AuthenticationJourneyPages.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AuthenticationJourneyPages.java
@@ -19,7 +19,7 @@ public enum AuthenticationJourneyPages {
     ENTER_PHONE_NUMBER("/enter-phone-number", "Enter your mobile phone number"),
     FINISH_CREATING_YOUR_ACCOUNT("/enter-phone-number", "Finish creating your account"),
     CHECK_YOUR_PHONE("/check-your-phone", "Check your phone"),
-    ACCOUNT_CREATED("/account-created", "You've created your GOV.UK account"),
+    ACCOUNT_CREATED("/account-created", "You’ve created your GOV.UK account"),
     ENTER_PASSWORD("/enter-password", "Enter your password"),
     ENTER_CODE("/enter-code", "Check your phone"),
     ENTER_EMAIL_EXISTING_USER(


### PR DESCRIPTION
## What?

Smart quotes in confirmation message, for typographical correctness:

![image](https://user-images.githubusercontent.com/23801/188196881-0b76ca6d-2cf0-48ae-b6a6-d38210dbe7bc.png)

## Why?

This PR will need to be merged if https://github.com/alphagov/di-authentication-frontend/pull/746 is merged

## Related PRs

https://github.com/alphagov/di-authentication-frontend/pull/746