### PR TITLE
Plat 1503: Added workflow and docker file for auth-deploy-pipeline

### DIFF
--- a/.github/workflows/build-and-push-tests.yaml
+++ b/.github/workflows/build-and-push-tests.yaml
@@ -1,0 +1,36 @@
+name: Build and Push Acceptance Tests
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: arn:aws:iam::761723964695:role/auth-deploy-pipeline-dev-GitHubActionsRole-17Z6L5D2KMOAC
+          aws-region: eu-west-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push acceptance tests image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: acceptance-tests-testrunnerimagerepository-yaqn2qfs5qn2
+          IMAGE_TAG: latest
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM docker
+
+RUN apk update && apk add --update --no-cache \
+    bash \
+    curl \
+    openjdk17 \
+    jq \
+    firefox \
+    aws-cli \
+    uuidgen \
+    argon2
+
+# install geckodriver
+RUN curl -L https://github.com/mozilla/geckodriver/releases/download/v0.33.0/geckodriver-v0.33.0-linux64.tar.gz | tar xz -C /usr/local/bin
+
+COPY . /test
+
+ENTRYPOINT ["/test/run-acceptance-tests.sh"]

--- a/reset-test-data.sh
+++ b/reset-test-data.sh
@@ -2,6 +2,8 @@
 
 set -eu
 
+ENVIRONMENT=${1:-local}
+
 source ./scripts/database.sh
 source ./scripts/reset-test-users.sh
 
@@ -21,15 +23,17 @@ done
 echo -e "Resetting di-authentication-acceptance-tests test data..."
 
 export AWS_REGION=eu-west-2
-export ENVIRONMENT_NAME=build
+export ENVIRONMENT_NAME=$ENVIRONMENT
 export GDS_AWS_ACCOUNT=digital-identity-dev
 
 if [ $LOCAL == "1" ]; then
   export $(grep -v '^#' .env | xargs)
 fi
 
-echo -e "Getting AWS credentials ..."
-eval "$(gds aws ${GDS_AWS_ACCOUNT} -e)"
-echo "done!"
+if [ $LOCAL == "1" ]; then
+  echo -e "Getting AWS credentials ..."
+  eval "$(gds aws ${GDS_AWS_ACCOUNT} -e)"
+  echo "done!"
+fi
 
 resetTestUsers


### PR DESCRIPTION
## What & Why?

To enable to use of the acceptance-tests with the `auth-deploy-pipeline` the following has been created:
- Added a docker file to create a container for the pipeline
- Added a build and push tests GHA workflow

[PLAT-1503: Create acceptance-tests workflow and generate test data](https://govukverify.atlassian.net/browse/PLAT-1503)
Passing build: 
