### PR TITLE
AUT-1944 - resolved unneccessarily long waits when checking for elements non presence

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/BasePage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/BasePage.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -117,10 +118,23 @@ public class BasePage {
         continueButton.click();
     }
 
-    protected boolean isLinkTextDisplayed(String linkText) {
+    public void switchDefaultTimeout(String status) {
+        switch (status.toLowerCase()) {
+            case "on":
+                driver.manage().timeouts().implicitlyWait(DEFAULT_PAGE_LOAD_WAIT_TIME);
+                break;
+            case "off":
+                driver.manage().timeouts().implicitlyWait(0, TimeUnit.SECONDS);
+                break;
+        }
+    }
+
+    protected boolean isLinkTextDisplayedImmediately(String linkText) {
+        switchDefaultTimeout("off");
         List elements =
                 driver.findElements(
                         By.xpath("//*[text()[normalize-space() = '" + linkText + "']]"));
+        switchDefaultTimeout("off");
         if (elements.size() > 0) {
             return true;
         } else {

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
@@ -1,5 +1,6 @@
 package uk.gov.di.test.step_definitions;
 
+import io.cucumber.java.en.And;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import org.openqa.selenium.By;
@@ -42,7 +43,7 @@ public class CommonStepDef extends BasePage {
 
     @Then("the link {string} is not available")
     public void theLinkIsNotAvailable(String linkText) {
-        assertFalse(isLinkTextDisplayed(linkText));
+        assertFalse(isLinkTextDisplayedImmediately(linkText));
     }
 
     @When("the user clicks the continue button")
@@ -51,7 +52,15 @@ public class CommonStepDef extends BasePage {
     }
 
     @Then("the user is returned to the service")
-    public void theUserIsReturnedToTheService() {}
+    public void theUserIsReturnedToTheService() {
+        waitForPageLoad("Example - GOV.UK - User Info");
+    }
+
+    @And("the user logs out")
+    public void theUserLogsOut() {
+        findAndClickButtonByText("Log out");
+        waitForPageLoad("Signed out");
+    }
 
     @Then("the user is shown an error message")
     public void theUserIsShownAnErrorMessageOnTheEnterEmailPage() {
@@ -60,7 +69,9 @@ public class CommonStepDef extends BasePage {
 
     @Then("the user is not shown any error messages")
     public void theNewUserIsNotShownAnErrorMessage() {
+        switchDefaultTimeout("off");
         List<WebElement> errorFields = driver.findElements(By.id("code-error"));
+        switchDefaultTimeout("on");
         if (!errorFields.isEmpty()) {
             System.out.println("setup-authenticator-app error: " + errorFields.get(0));
         }

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/003_legal_and_policy_pages.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/003_legal_and_policy_pages.feature
@@ -27,6 +27,5 @@ Feature: Legal and policy pages
     When the user enters the six digit security code from their phone
     Then the user is taken to the "terms of use update" page
     When the user agrees to the updated terms and conditions
-    Then the user is taken to the "Example - GOV.UK - User Info" page
-    When the user clicks logout
-    Then the user is taken to the "Signed out" page
+    Then the user is returned to the service
+    And the user logs out

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/005_auth_app_2fa_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/005_auth_app_2fa_journey.feature
@@ -21,8 +21,7 @@ Feature: Authentication App Journeys
     And the user is taken to the "You’ve created your GOV.UK One Login" page
     When the user clicks the continue button
     Then the user is returned to the service
-    When the user clicks logout
-    Then the user is taken to the "Signed out" page
+    And the user logs out
 
     When the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
@@ -34,8 +33,7 @@ Feature: Authentication App Journeys
     Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
     When the user enters the security code from the auth app
     Then the user is returned to the service
-    When the user clicks logout
-    Then the user is taken to the "Signed out" page
+    And the user logs out
 
   Scenario: User successfully login without 2FA
     Given the user comes from the stub relying party with options: "2fa-off"
@@ -46,8 +44,7 @@ Feature: Authentication App Journeys
     Then the user is taken to the "Enter your password" page
     When the user enters their password
     Then the user is returned to the service
-    When the user clicks logout
-    Then the user is taken to the "Signed out" page
+    And the user logs out
 
   Scenario: User signs in auth app without 2FA, then uplifts
     Given the user comes from the stub relying party with options: "2fa-off"

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/006_registration_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/006_registration_journey.feature
@@ -80,5 +80,4 @@ Feature: Registration Journey
     Then the user is taken to the "You’ve created your GOV.UK One Login" page
     When the user clicks the continue button
     Then the user is returned to the service
-    When the user clicks logout
-    Then the user is taken to the "Signed out" page
+    And the user logs out

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/010_existing_user_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/010_existing_user_journey.feature
@@ -16,7 +16,6 @@ Feature: Login Journey
     When the user clicks the get a new code link
     Then the user is taken to the "You cannot get a new security code at the moment" page
 
-
   Scenario: Existing user tries to create an account with the same email address
     Given the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
@@ -24,7 +23,6 @@ Feature: Login Journey
     Then the user is taken to the "Enter your email address" page
     When user enters "TEST_USER_2_EMAIL" email address
     Then the user is taken to the "You have a GOV.UK One Login" page
-
 
   Scenario: Existing user is correctly prompted to login using sms
     Given the user comes from the stub relying party with options: "default"
@@ -37,9 +35,7 @@ Feature: Login Journey
     Then the user is taken to the "Check your phone" page
     When the user enters the six digit security code from their phone
     Then the user is returned to the service
-    And the user clicks logout
-    Then the user is taken to the "Signed out" page
-
+    And the user logs out
 
   Scenario: Existing user switches content to Welsh
     Given the user comes from the stub relying party with options: "default"
@@ -57,7 +53,6 @@ Feature: Login Journey
     When the user switches to "English" language
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
 
-
   Scenario: Existing user logs in without 2FA then uplift with 2FA
     Given the user comes from the stub relying party with options: "2fa-off"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
@@ -71,5 +66,4 @@ Feature: Login Journey
     Then the user is taken to the "You need to enter a security code" page
     When the user enters the six digit security code from their phone
     Then the user is returned to the service
-    When the user clicks logout
-    Then the user is taken to the "Signed out" page
+    And the user logs out

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/Enforce_100k_password_check.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/Enforce_100k_password_check.feature
@@ -20,6 +20,5 @@ Feature: Enforce 100k password check
     When the user enters valid new password and correctly retypes it
     Then the user is taken to the "Check your phone" page
     When the user enters the six digit security code from their phone
-    Then the user is taken to the "Example - GOV.UK - User Info" page
-    When the user clicks logout
-    Then the user is taken to the "Signed out" page
+    Then the user is returned to the service
+    And the user logs out

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/IPN.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/IPN.feature
@@ -24,8 +24,6 @@ Feature: International Phone Numbers
     When the user submits a UK phone number containing non-digit characters
     Then the "Enter a UK mobile phone number using only numbers or the + symbol" error message is displayed
 
-
-
   Scenario: User can successfully complete registration using an international phone number
     Given the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
@@ -53,9 +51,7 @@ Feature: International Phone Numbers
     Then the user is taken to the "You’ve created your GOV.UK One Login" page
     When the user clicks the continue button
     Then the user is returned to the service
-    When the user clicks logout
-    Then the user is taken to the "Signed out" page
-
+    And the user logs out
 
 #  Scenario: User with an international phone number reports that they did not receive their security code
 #    Given the user comes from the stub relying party with options: "default"

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/Reset_password.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/Reset_password.feature
@@ -23,9 +23,8 @@ Feature: Reset password
     When the user enters valid new password and correctly retypes it
     Then the user is taken to the "Check your phone" page
     When the user enters the six digit security code from their phone
-    Then the user is taken to the "Example - GOV.UK - User Info" page
-    When the user clicks logout
-    Then the user is taken to the "Signed out" page
+    Then the user is returned to the service
+    And the user logs out
 
 # REQUEST OTP TOO MANY TIMES DURING PASSWORD RESET --- AUT-1274
   Scenario: A user is blocked when they request an email OTP more than 5 times during a password reset.

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/account_recovery.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/account_recovery.feature
@@ -17,9 +17,8 @@ Feature: Account recovery
     When the user selects "Problems with the code?" link
     Then the link "change how you get security codes" is not available
     When the user enters the six digit security code from their phone
-    Then the user is taken to the "Example - GOV.UK - User Info" page
-    When the user clicks logout
-    Then the user is taken to the "Signed out" page
+    Then the user is returned to the service
+    And the user logs out
 
     When the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
@@ -40,9 +39,8 @@ Feature: Account recovery
     And the user enters the security code from the auth app
     Then the user is taken to the "You’ve changed how you get security codes" page
     And confirmation that the user will get security codes via "auth app" is displayed
-    Then the user is taken to the "Example - GOV.UK - User Info" page
-    When the user clicks logout
-    Then the user is taken to the "Signed out" page
+    Then the user is returned to the service
+    And the user logs out
 
     When the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
@@ -53,9 +51,8 @@ Feature: Account recovery
     When the user enters their new password
     Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
     When the user enters the security code from the auth app
-    Then the user is taken to the "Example - GOV.UK - User Info" page
-    When the user clicks logout
-    Then the user is taken to the "Signed out" page
+    Then the user is returned to the service
+    And the user logs out
 
 
   Scenario: A user with auth app authentication changes password and logs in with their MFA. Changes their auth method to text message, then logs in with the new password and text message auth method.
@@ -74,9 +71,8 @@ Feature: Account recovery
     And the link "I do not have access to the authenticator app" is not available
     And the link "change how you get security codes" is not available
     When the user enters the security code from the auth app
-    Then the user is taken to the "Example - GOV.UK - User Info" page
-    When the user clicks logout
-    Then the user is taken to the "Signed out" page
+    Then the user is returned to the service
+    And the user logs out
 
     When the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
@@ -98,9 +94,8 @@ Feature: Account recovery
     When the user enters the six digit security code from their phone
     Then the user is taken to the "You’ve changed how you get security codes" page
     And confirmation that the user will get security codes via "text message" is displayed
-    Then the user is taken to the "Example - GOV.UK - User Info" page
-    When the user clicks logout
-    Then the user is taken to the "Signed out" page
+    Then the user is returned to the service
+    And the user logs out
 
     When the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
@@ -111,9 +106,8 @@ Feature: Account recovery
     When the user enters their new password
     Then the user is taken to the "Check your phone" page
     When the user enters the six digit security code from their phone
-    Then the user is taken to the "Example - GOV.UK - User Info" page
-    When the user clicks logout
-    Then the user is taken to the "Signed out" page
+    Then the user is returned to the service
+    And the user logs out
 
 
   Scenario: A user with sms authentication is blocked when they request their email OTP code 6 times (including the initial send on entry to screen) during a change of auth method.


### PR DESCRIPTION
Resolved unneccessarily long waits when checking for element non presence, and resolve issue with log out steps where it sometimes went out of sync

## What?
1. Resolved unneccessarily long waits when checking for element non presence
2. Resolved occasional issue where the log out steps went out of sync

## Why?

1. To reduce execution time (particularly in Firefox)
2. To reduce test failures