### PR TITLE
Changing Acceptance test to run on Chrome browser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,6 @@ RUN apk update && apk add --update --no-cache \
 
 ENV PATH="/usr/bin/chromedriver:${PATH}"
 
-# install geckodriver
-#RUN curl -L https://github.com/mozilla/geckodriver/releases/download/v0.33.0/geckodriver-v0.33.0-linux64.tar.gz | tar xz -C /usr/local/bin
-
 COPY . /test
 
 RUN addgroup -S auth_user_group

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,46 @@ RUN apk update && apk add --update --no-cache \
     curl \
     openjdk17 \
     jq \
-    firefox \
     aws-cli \
     uuidgen \
-    argon2
+    argon2 \
+    alsa-lib \
+    cairo \
+    cups-libs \
+    dbus-libs \
+    eudev-libs \
+    expat \
+    flac \
+    gdk-pixbuf \
+    glib \
+    libgcc \
+    libjpeg-turbo \
+    libpng \
+    libwebp \
+    libx11 \
+    libxcomposite \
+    libxdamage \
+    libxext \
+    libxfixes \
+    tzdata \
+    libexif \
+    udev \
+    xvfb \
+    zlib-dev \
+    chromium \
+    chromium-chromedriver
+
+ENV PATH="/usr/bin/chromedriver:${PATH}"
 
 # install geckodriver
-RUN curl -L https://github.com/mozilla/geckodriver/releases/download/v0.33.0/geckodriver-v0.33.0-linux64.tar.gz | tar xz -C /usr/local/bin
+#RUN curl -L https://github.com/mozilla/geckodriver/releases/download/v0.33.0/geckodriver-v0.33.0-linux64.tar.gz | tar xz -C /usr/local/bin
 
 COPY . /test
+
+RUN addgroup -S auth_user_group
+RUN adduser -S authuser -G auth_user_group
+RUN chown -R authuser: /test
+RUN chmod -R u+rwx /test
+USER authuser
 
 ENTRYPOINT ["/test/run-acceptance-tests.sh"]

--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/BasePage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/BasePage.java
@@ -61,7 +61,12 @@ public class BasePage {
                     ChromeOptions chromeOptions = new ChromeOptions();
                     chromeOptions.setHeadless(SELENIUM_HEADLESS);
                     chromeOptions.addArguments("--remote-allow-origins=*");
+                    chromeOptions.addArguments("--disable-gpu");
+                    chromeOptions.addArguments("--disable-extensions");
+                    chromeOptions.addArguments("--no-sandbox");
+                    chromeOptions.addArguments("--disable-dev-shm-usage");
                     if (SELENIUM_LOCAL) {
+                        System.setProperty("webdriver.chrome.whitelistedIps", "");
                         driver = new ChromeDriver(chromeOptions);
                     } else {
                         driver = new RemoteWebDriver(new URL(SELENIUM_URL), chromeOptions);

--- a/run-acceptance-tests.sh
+++ b/run-acceptance-tests.sh
@@ -77,7 +77,7 @@ function get_env_vars_from_SSM() {
 
 function export_selenium_config() {
   export SELENIUM_URL="http://localhost:4444/wd/hub"
-  export SELENIUM_BROWSER=firefox
+  export SELENIUM_BROWSER=chrome
   export SELENIUM_LOCAL=true
   export SELENIUM_HEADLESS=true
   export DEBUG_MODE=false


### PR DESCRIPTION
## What?

Please include a summary of the change.

AUT-1174 : Switch acceptance tests to run on Chrome in the pipeline

This Change is to run acceptance test in pipeline to run on Chrome Browser

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.