### PR TITLE
BAU: Ability to run acceptance tests locally against staging

### DIFF
--- a/reset-test-data.sh
+++ b/reset-test-data.sh
@@ -23,17 +23,18 @@ while getopts "lr" opt; do
   esac
 done
 
-echo -e "Resetting di-authentication-acceptance-tests test data..."
+echo -e "Resetting di-authentication-acceptance-tests test data in ${ENVIRONMENT}..."
 
 export AWS_REGION=eu-west-2
 export ENVIRONMENT_NAME=$ENVIRONMENT
-export GDS_AWS_ACCOUNT=digital-identity-dev
 
 if [ $LOCAL == "1" ]; then
   export $(grep -v '^#' .env | xargs)
-fi
-
-if [ $LOCAL == "1" ]; then
+  if [ $ENVIRONMENT == "staging" ]; then
+    export GDS_AWS_ACCOUNT=di-auth-staging
+  else
+    export GDS_AWS_ACCOUNT=digital-identity-dev
+  fi
   echo -e "Getting AWS credentials ..."
   eval "$(gds aws ${GDS_AWS_ACCOUNT} -e)"
   echo "done!"

--- a/run-acceptance-tests.sh
+++ b/run-acceptance-tests.sh
@@ -111,7 +111,7 @@ else
 fi
 
 if [ $LOCAL == "1" ]; then
-  ./reset-test-data.sh -l
+  ./reset-test-data.sh -l $ENVIRONMENT
 else
   ./reset-test-data.sh -r $ENVIRONMENT
 fi


### PR DESCRIPTION
## What?

Ability to run acceptance tests locally against staging.

Make sure you have the correct environment variables then run the following command:

`./run-acceptance-tests.sh -l staging
`

A further change to the pipeline is required to permanently update the test user allowlist in staging.

## Why?

Able to test what is deployed to staging and work on additional acceptance tests that are not yet ready to be used in the pipeline.

