### PR TITLE
AUT-2485: Fix pipeline deploy

### DIFF
--- a/run-acceptance-tests.sh
+++ b/run-acceptance-tests.sh
@@ -41,9 +41,6 @@ function stop_docker_services() {
 }
 
 function get_env_vars_from_SSM() {
-  export AWS_PROFILE="gds-di-development-admin"
-  # shellcheck source=./scripts/export_aws_creds.sh
-  source "${DIR}/scripts/export_aws_creds.sh"
 
   echo "Getting environment variables from SSM ... "
   if [ $EXPORT_ENV == "1" ]; then
@@ -102,11 +99,14 @@ echo -e "Running di-authentication-acceptance-tests..."
 
 start_docker_services selenium-firefox selenium-chrome
 
+export_selenium_config
 if [ $LOCAL == "1" ]; then
-  export_selenium_config
-  export $(grep -v '^#' .env | xargs)
+  # shellcheck source=/dev/null
+  set -o allexport && source .env && set +o allexport
 else
-  export_selenium_config
+  export AWS_PROFILE="gds-di-development-admin"
+  # shellcheck source=./scripts/export_aws_creds.sh
+  source "${DIR}/scripts/export_aws_creds.sh"
   get_env_vars_from_SSM
 fi
 

--- a/scripts/export_aws_creds.sh
+++ b/scripts/export_aws_creds.sh
@@ -12,7 +12,9 @@ if [[ -n "${AWS_VAULT:-}" ]]; then
   echo "In future, this script will error and exit here, not show a warning." >&2
 fi
 
-if [[ -n "${AWS_ACCESS_KEY_ID:-}" && -n "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+if [[ -n "${CODEBUILD_BUILD_ID:-}" ]]; then
+  true # Running in CodeBuild, do nothing
+elif [[ -n "${AWS_ACCESS_KEY_ID:-}" && -n "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
   echo "Using AWS credentials from existing environment variables"
   export AWS_REGION="${AWS_REGION:-eu-west-2}"
 else
@@ -41,3 +43,4 @@ else
   configured_region="$(aws configure get region --profile "${AWS_PROFILE}" 2>/dev/null || true)"
   export AWS_REGION="${configured_region:-eu-west-2}"
 fi
+unset AWS_PROFILE


### PR DESCRIPTION
## What?

If deploying in codebuild, don't try to export AWS credentials.

## Why?

They're all in the environment already.

Codebuild sets various envars that we don't have locally: https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html

We check if one of these exists: if it does, do nothing and just unset AWS_PROFILE.
