### PR TITLE
AUT-1540: Update title for the enter code screen on uplift journeys

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/utils/AuthenticationJourneyPages.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/utils/AuthenticationJourneyPages.java
@@ -9,7 +9,7 @@ public enum AuthenticationJourneyPages {
     CHECK_YOUR_PHONE("/check-your-phone", "Check your phone"),
     ACCOUNT_CREATED("/account-created", "You’ve created your GOV.UK One Login"),
     ENTER_PASSWORD("/enter-password", "Enter your password"),
-    ENTER_CODE_UPLIFT("/enter-code", "You need to enter a security code"),
+    ENTER_CODE_UPLIFT("/enter-code", "Enter a security code to continue"),
     ENTER_EMAIL_EXISTING_USER(
             "/enter-email", "Enter your email address to sign in to your GOV.UK One Login"),
     RESEND_SECURITY_CODE("/resend-code", "Get security code");

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/005_auth_app_2fa_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/005_auth_app_2fa_journey.feature
@@ -56,4 +56,4 @@ Feature: Authentication App Journeys
     When the user enters their password
     Then the user is returned to the service
     When the user comes from the stub relying party with options: "default"
-    Then the user is taken to the "You need to enter a security code" page
+    Then the user is taken to the "Enter a security code to continue" page

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/010_existing_user_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/010_existing_user_journey.feature
@@ -63,7 +63,7 @@ Feature: Login Journey
     When the user enters their password
     Then the user is returned to the service
     When the user comes from the stub relying party with options: "default"
-    Then the user is taken to the "You need to enter a security code" page
+    Then the user is taken to the "Enter a security code to continue" page
     When the user enters the six digit security code from their phone
     Then the user is returned to the service
     And the user logs out


### PR DESCRIPTION
## What?

Updates the title for the enter code screen presented on uplift journeys

## Why?

To reflect changes to the title and heading introduced in https://github.com/govuk-one-login/authentication-frontend/pull/1438

## Related PRs

- https://github.com/govuk-one-login/authentication-frontend/pull/1438