### PR TITLE
BAU: run acceptance tests against dev environments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,16 @@ version: '3.8'
 services:
   selenium-firefox:
     image: selenium/standalone-firefox@sha256:02bd079b1e53a2abc4923fe84262df5a9e9de020d29f7c6552e4e7f663599e4d
+    #USE THESE VALUES IF YOU HAVE A MAC M1/M2/M3 (ARM) chip
+    #image: seleniarm/standalone-firefox:latest
     ports:
       - 4444:4444
     networks:
       - op-net
   selenium-chrome:
     image: selenium/standalone-chrome@sha256:36784cc22ea01886ac226146be343afe7d984d9fc69436e52c2c0f8fd0dc0f55
+    #USE THESE VALUES IF YOU HAVE A MAC M1/M2/M3 (ARM) chip
+    #image: seleniarm/standalone-chromium:latest
     ports:
       - 4445:4444
     networks:

--- a/reset-test-data.sh
+++ b/reset-test-data.sh
@@ -35,10 +35,15 @@ export ENVIRONMENT_NAME="${ENVIRONMENT}"
 if [ "${LOCAL}" == "1" ]; then
   # shellcheck source=/dev/null
   set -o allexport && source .env && set +o allexport
+  echo "reset-test-data ENVIRONMENT: ${ENVIRONMENT}"
   if [ "${ENVIRONMENT}" == "staging" ]; then
     export AWS_PROFILE="di-auth-staging-admin"
   else
-    export AWS_PROFILE="gds-di-development-admin"
+    if [ "${ENVIRONMENT}" == "authdev1" ] || [ "${ENVIRONMENT}" == "authdev2" ]; then
+        export AWS_PROFILE="di-auth-development-admin"
+    else
+        export AWS_PROFILE="gds-di-development-admin"
+    fi
   fi
   # shellcheck source=./scripts/export_aws_creds.sh
   source "${DIR}/scripts/export_aws_creds.sh"

--- a/run-acceptance-tests-against-dev-env.sh
+++ b/run-acceptance-tests-against-dev-env.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+set -eu
+
+envvalue=("sandpit" "authdev1" "authdev2")
+
+select word in "${envvalue[@]}"; do
+  if [[ -z "$word" ]]; then
+    printf '"%s" is not a valid choice\n' "$REPLY" >&2
+  else
+    user_in="$((REPLY - 1))"
+    break
+  fi
+done
+
+for ((i = 0; i < ${#envvalue[@]}; ++i)); do
+  if ((i == user_in)); then
+    printf 'You picked "%s"\n' "${envvalue[$i]}"
+    export ENVIRONMENT=${envvalue[$i]}
+    printf "Running AC tests against %s\n" "${ENVIRONMENT}"
+    read -r -p "Press enter to continue or Ctrl+C to abort"
+  fi
+done
+
+
+DOCKER_BASE=docker-compose
+SSM_VARS_PATH="/acceptance-tests/$ENVIRONMENT"
+TESTDIR="/test"
+
+echo "Running in $ENVIRONMENT environment..."
+
+function start_docker_services() {
+  ${DOCKER_BASE} up --build -d --wait --no-deps --quiet-pull "$@"
+}
+
+function stop_docker_services() {
+  ${DOCKER_BASE} down --rmi local --remove-orphans
+}
+
+function get_env_vars_from_SSM() {
+
+  echo "Getting environment variables from SSM ... "
+
+  VARS="$(aws ssm get-parameters-by-path --with-decryption --path $SSM_VARS_PATH | jq -r '.Parameters[] | @base64')"
+  for VAR in $VARS; do
+    VAR_NAME="$(echo ${VAR} | base64 -d | jq -r '.Name / "/" | .[3]')"
+    export "$VAR_NAME"="$(echo ${VAR} | base64 -d | jq -r '.Value')"
+  done
+  echo "Exported SSM parameters completed."
+}
+
+function export_selenium_config() {
+  export SELENIUM_URL="http://localhost:4444/wd/hub"
+  export SELENIUM_BROWSER=chrome
+  export SELENIUM_LOCAL=true
+  export SELENIUM_HEADLESS=true
+  export DEBUG_MODE=false
+}
+
+echo -e "Building di-authentication-acceptance-tests..."
+
+if [ -d "$TESTDIR" ]; then
+  echo "Changing to $TESTDIR"
+  cd $TESTDIR
+fi
+
+./gradlew clean spotlessApply build -x :acceptance-tests:test
+
+build_and_test_exit_code=$?
+if [ ${build_and_test_exit_code} -ne 0 ]; then
+  echo -e "acceptance-tests failed."
+  exit 1
+fi
+
+echo -e "Running di-authentication-acceptance-tests..."
+
+start_docker_services selenium-firefox selenium-chrome
+
+export_selenium_config
+
+set -o allexport && source .env && set +o allexport
+
+
+
+./reset-test-data.sh -l "$ENVIRONMENT"
+
+
+./gradlew cucumber
+
+build_and_test_exit_code=$?
+
+stop_docker_services selenium-firefox selenium-chrome
+
+if [ ${build_and_test_exit_code} -ne 0 ]; then
+  echo -e "acceptance-tests failed."
+
+else
+  echo -e "acceptance-tests SUCCEEDED."
+fi


### PR DESCRIPTION
## What?

Changes to allow users to run against a dev environment

## Why?

We need this so users can run ac tests against their changes without merging into main
A full description of the problem and the implementation of this PR has been done on [this confluence page](https://govukverify.atlassian.net/wiki/spaces/LO/pages/4193812628/Running+acceptance+tests+locally).
