### PR TITLE
AUT-3386: Create api acceptance test for update password

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -16,7 +16,8 @@ def dependencyVersions = [
         cucumber_version: '7.8.1',
         axe_version: '3.0',
         json_version: '20220320',
-        selenium_java_version: '4.5.0'
+        selenium_java_version: '4.5.0',
+        rest_assured: '5.5.0'
 ]
 
 dependencies {
@@ -31,6 +32,7 @@ dependencies {
 
     testImplementation group: 'com.deque', name: 'axe-selenium', version:"${dependencyVersions.axe_version}"
     testImplementation group: 'org.json', name: 'json', version:"${dependencyVersions.json_version}"
+    testImplementation "io.rest-assured:rest-assured:${dependencyVersions.rest_assured}"
 
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit_version}"
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/UserInformationPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/UserInformationPage.java
@@ -6,10 +6,15 @@ import uk.gov.di.test.utils.Driver;
 public class UserInformationPage extends BasePage {
 
     By idTokenField = By.id("user-info-id-token");
+    By accessTokenField = By.id("user-info-access-token");
     By logoutButton = By.name("logout");
 
     public String getIdToken() {
         return Driver.get().findElement(idTokenField).getText();
+    }
+
+    public String getAccessToken() {
+        return Driver.get().findElement(accessTokenField).getText();
     }
 
     public void logoutOfAccount() {

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/AccountManagementStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/AccountManagementStepDef.java
@@ -1,0 +1,37 @@
+package uk.gov.di.test.step_definitions;
+
+import io.cucumber.java.en.When;
+import org.hamcrest.Matchers;
+import org.json.JSONObject;
+import uk.gov.di.test.pages.UserInformationPage;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+
+public class AccountManagementStepDef {
+    UserInformationPage userInformationPage = new UserInformationPage();
+
+    @When(
+            "the test calls the Account Management Update Password API with the access token and validates response")
+    public void theUserIsReturnedToTheService() {
+        JSONObject obj = new JSONObject(userInformationPage.getAccessToken());
+        String bearerJWT = obj.getString("access_token");
+        String bearerToken = "Bearer ".concat(bearerJWT);
+
+        String body =
+                "{\n    \"email\":\""
+                        + System.getenv("NONEXISTENT_USER_ACCOUNT_MANAGEMENT_EMAIL")
+                        + "\",\n"
+                        + "    \"newPassword\":\"testPassword123!\"\n"
+                        + "}";
+        given().headers(Map.of("Authorization", bearerToken))
+                .body(body)
+                .when()
+                .post(System.getenv("INTERNAL_AM_API").concat("/update-password"))
+                .then()
+                .statusCode(400)
+                .body("code", Matchers.is(1010))
+                .body("message", Matchers.is("An account with this email address does not exist"));
+    }
+}

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/LoginStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/LoginStepDef.java
@@ -300,4 +300,15 @@ public class LoginStepDef extends BasePage {
     public void theUserChangesTheirPasswordDuringReauth() {
         crossPageFlows.smsUserChangesPassword();
     }
+
+    @When("the user enters {string} email address, password and six digit SMS OTP")
+    public void theUserGoesThroughSmsSignInJourney(String email) {
+        theUserSelectsSignIn();
+        waitForPageLoad("Enter your email");
+        enterYourEmailAddressToSignInPage.enterEmailAddressAndContinue(System.getenv().get(email));
+        waitForPageLoad("Enter your password");
+        enterYourPasswordPage.enterCorrectPasswordAndContinue();
+        waitForPageLoad("Check your phone");
+        checkYourPhonePage.enterCorrectPhoneCodeAndContinue();
+    }
 }

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/Account_management_apis.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/Account_management_apis.feature
@@ -1,0 +1,8 @@
+@AccountManagement @build @staging
+  Feature: Account Management
+    Scenario: Account Management API throws "An account with this email address does not exist" when a user sends an unregistered email to the API, after signing in
+      Given the user comes from the stub relying party with options: "scopes-account-management"
+      When the user enters "TEST_USER_ACCOUNT_MANAGEMENT_EMAIL" email address, password and six digit SMS OTP
+      Then the user is returned to the service
+      When the test calls the Account Management Update Password API with the access token and validates response
+      Then the user clicks logout

--- a/reset-test-data.sh
+++ b/reset-test-data.sh
@@ -11,6 +11,7 @@ source ./scripts/reset-test-users.sh
 source ./scripts/reset-account-interventions.sh
 source ./scripts/re-authentication.sh
 source ./scripts/2hr-lockout-period.sh
+source ./scripts/reset-account-management.sh
 
 LOCAL=0
 while getopts "lr" opt; do
@@ -53,3 +54,4 @@ resetTestUsers
 resetAccountInterventions
 #reAuthentication
 2hrLockoutPeriod
+resetAccountManagement

--- a/scripts/reset-account-management.sh
+++ b/scripts/reset-account-management.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+function resetAccountManagement() {
+    createSMSUser \
+        $TEST_USER_ACCOUNT_MANAGEMENT_EMAIL \
+        $TEST_USER_PASSWORD \
+        $TEST_USER_PHONE_NUMBER \
+        $TEST_USER_LATEST_TERMS_AND_CONDITIONS_VERSION
+
+    deleteUser $NONEXISTENT_USER_ACCOUNT_MANAGEMENT_EMAIL
+}


### PR DESCRIPTION
## What?

Create an acceptance test that verify that the internal account management update password API is un and running correctly.

## Why?

We need automated tests for internal am APIs.

