### PR TITLE
AUT-3504 - Sign acceptance-tests image with Container Signer key

### DIFF
--- a/.github/workflows/build-and-push-tests-SP.yaml
+++ b/.github/workflows/build-and-push-tests-SP.yaml
@@ -29,11 +29,18 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: 'v1.9.0'
+
       - name: Build, tag, and push acceptance tests image to Amazon ECR
         env:
+          CONTAINER_SIGN_KMS_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ secrets.ACCEPTANCE_ECR_REPO_NEW_BUILD }}
           IMAGE_TAG: latest
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          cosign sign --key awskms:///${CONTAINER_SIGN_KMS_KEY} $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG


### PR DESCRIPTION
Issue: [AUT-3504]

## What?

Sign acceptance-tests image with Container Signer key, in the SP GitHub workflow

## Why?

Following the secure pipeline image signing standards

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.

[AUT-3504]: https://govukverify.atlassian.net/browse/AUT-3504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ