### PR TITLE
BAU - updated Selenium to 4.23.1 and replaced the deprecated setHeadl…

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -16,7 +16,7 @@ def dependencyVersions = [
         cucumber_version: '7.8.1',
         axe_version: '3.0',
         json_version: '20220320',
-        selenium_java_version: '4.5.0',
+        selenium_java_version: '4.23.1',
         rest_assured: '5.5.0'
 ]
 

--- a/acceptance-tests/src/test/java/uk/gov/di/test/utils/Driver.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/utils/Driver.java
@@ -37,7 +37,9 @@ public class Driver {
                 switch (SELENIUM_BROWSER) {
                     case "chrome":
                         ChromeOptions chromeOptions = new ChromeOptions();
-                        chromeOptions.setHeadless(SELENIUM_HEADLESS);
+                        if (SELENIUM_HEADLESS) {
+                            chromeOptions.addArguments("--headless=new");
+                        }
                         chromeOptions.addArguments("--remote-allow-origins=*");
                         chromeOptions.addArguments("--disable-gpu");
                         chromeOptions.addArguments("--disable-extensions");
@@ -59,7 +61,9 @@ public class Driver {
 
                     case "firefox":
                         FirefoxOptions firefoxOptions = new FirefoxOptions();
-                        firefoxOptions.setHeadless(SELENIUM_HEADLESS);
+                        if (SELENIUM_HEADLESS) {
+                            firefoxOptions.addArguments("--headless=new");
+                        }
                         firefoxOptions.setPageLoadTimeout(Duration.of(30, SECONDS));
                         firefoxOptions.setImplicitWaitTimeout(Duration.of(30, SECONDS));
                         if (SELENIUM_LOCAL) {


### PR DESCRIPTION
## What?

Upped Selenium version to 4.23.1, and replaced deprecated setHeadless with addArguments

## Why?

Old version of Selenium possibly causing intermittent issues during pipeline runs