### PR TITLE
BAU - bumped surefire plugin version

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -21,7 +21,7 @@ def dependencyVersions = [
 ]
 
 dependencies {
-    implementation group: 'org.apache.maven.plugins', name: 'maven-surefire-plugin', version: '3.2.5'
+    implementation group: 'org.apache.maven.plugins', name: 'maven-surefire-plugin', version: '3.4.0'
 
     testImplementation "io.cucumber:cucumber-java:${dependencyVersions.cucumber_version}",
                        "io.cucumber:cucumber-junit:${dependencyVersions.cucumber_version}",


### PR DESCRIPTION
## What?

Bumped surefire plugin version to 3.4.0

## Why?

It was out of date and dependabot didn't work.