### PR TITLE
BAU: Print the user session ID on after all page loads to the console

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/RpStubPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/RpStubPage.java
@@ -18,8 +18,6 @@ public class RpStubPage extends BasePage {
                 Driver.get().findElement(By.id(id)).click();
             }
         }
-        System.out.println(
-                "One Login session cookie: " + Driver.get().manage().getCookieNamed("gs"));
         findAndClickContinue();
     }
 

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
@@ -26,6 +26,8 @@ public class CommonStepDef extends BasePage {
     @Then("the user is taken to the {string} page")
     public void theUserIsTakenToThePage(String pageTitle) {
         waitForPageLoad(pageTitle);
+        System.out.println(
+                "One Login session cookie: " + Driver.get().manage().getCookieNamed("gs"));
     }
 
     @Then("the {string} error message is displayed")


### PR DESCRIPTION
Also revert the previous commit that put this on RPStub page loads. Didn't work in the end due to the cookie we care about being on a different domain than the stub page.

## Why?

Useful for associating sessions from acceptance tests with AWS resource logs

## Related PRs

https://github.com/govuk-one-login/authentication-acceptance-tests/pull/409