### PR TITLE
AUT-3710: Run selenium locally rather than starting and connecting to the remote selenium containers

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/utils/Driver.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/utils/Driver.java
@@ -18,7 +18,7 @@ public class Driver {
     protected static final String SELENIUM_URL =
             System.getenv().getOrDefault("SELENIUM_URL", "http://localhost:4445/wd/hub");
     protected static final Boolean SELENIUM_LOCAL =
-            Boolean.parseBoolean(System.getenv().getOrDefault("SELENIUM_LOCAL", "false"));
+            Boolean.parseBoolean(System.getenv().getOrDefault("SELENIUM_LOCAL", "true"));
     protected static final Boolean SELENIUM_HEADLESS =
             Boolean.parseBoolean(System.getenv().getOrDefault("SELENIUM_HEADLESS", "false"));
     protected static final String SELENIUM_BROWSER =

--- a/run-acceptance-tests.sh
+++ b/run-acceptance-tests.sh
@@ -32,14 +32,6 @@ done
 
 echo "Running in $ENVIRONMENT environment..."
 
-function start_docker_services() {
-  ${DOCKER_BASE} up --build -d --wait --no-deps --quiet-pull "$@"
-}
-
-function stop_docker_services() {
-  ${DOCKER_BASE} down --rmi local --remove-orphans
-}
-
 function get_env_vars_from_SSM() {
 
   echo "Getting environment variables from SSM ... "
@@ -97,8 +89,6 @@ fi
 
 echo -e "Running di-authentication-acceptance-tests..."
 
-start_docker_services selenium-firefox selenium-chrome
-
 export_selenium_config
 if [ $LOCAL == "1" ]; then
   # shellcheck source=/dev/null
@@ -119,8 +109,6 @@ fi
 ./gradlew cucumber
 
 build_and_test_exit_code=$?
-
-stop_docker_services selenium-firefox selenium-chrome
 
 if [ ${build_and_test_exit_code} -ne 0 ]; then
   echo -e "acceptance-tests failed."


### PR DESCRIPTION

## What?

Run selenium locally rather than starting and connecting to the remote selenium containers.

Don't start and stop the selenium containers.
Set SELENIUM_LOCAL to false by default

Tested by pushing the image to the dev environment and running the tests in the pipeline (note that tests don't all run successfully in dev at the moment, but the fact that any tests can run proves that the change works.

Before change, note 

`
Container test-selenium-firefox-1  Creating
Container test-selenium-chrome-1  Creating
`

https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/761723964695/projects/Test-build-auth-deploy-pipeline/build/Test-build-auth-deploy-pipeline%3A0c382c28-f129-4c9b-83ab-dd291404db66/?region=eu-west-2

After change no selenium containers started:

https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/653994557586/projects/Test-dev-auth-deploy-pipeline/build/Test-dev-auth-deploy-pipeline%3Afbc3fb33-6a5e-4b35-a14a-375687eb8807?region=eu-west-2#

## Why?

This should remove the extra overhead required to use Docker and the network traffic to connect to the containers
