### PR TITLE
AUT-3549 - Acceptance test configurations for secure pipeline compatibility

### DIFF
--- a/.github/workflows/build-and-push-tests-SP.yaml
+++ b/.github/workflows/build-and-push-tests-SP.yaml
@@ -17,17 +17,17 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.GHA_DEPLOYER_ROLE_NEW_BUILD }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@main
@@ -41,6 +41,6 @@ jobs:
           ECR_REPOSITORY: ${{ secrets.ACCEPTANCE_ECR_REPO_NEW_BUILD }}
           IMAGE_TAG: latest
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f Dockerfile.sp .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           cosign sign --key awskms:///${CONTAINER_SIGN_KMS_KEY} $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/build-and-push-tests-dev.yaml
+++ b/.github/workflows/build-and-push-tests-dev.yaml
@@ -17,17 +17,17 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.DEV_GHA_DEPLOYER_ROLE }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Build, tag, and push acceptance tests image to Amazon ECR
         env:
@@ -35,5 +35,5 @@ jobs:
           ECR_REPOSITORY: ${{ env.DEV_ACCEPTANCE_ECR_REPO }}
           IMAGE_TAG: latest
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f Dockerfile.sp .
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/build-and-push-tests-dev.yaml
+++ b/.github/workflows/build-and-push-tests-dev.yaml
@@ -35,5 +35,5 @@ jobs:
           ECR_REPOSITORY: ${{ env.DEV_ACCEPTANCE_ECR_REPO }}
           IMAGE_TAG: latest
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f Dockerfile.sp .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/Dockerfile.sp
+++ b/Dockerfile.sp
@@ -1,0 +1,48 @@
+FROM docker
+
+RUN apk update && apk add --update --no-cache \
+    bash \
+    curl \
+    openjdk17 \
+    jq \
+    aws-cli \
+    uuidgen \
+    argon2 \
+    alsa-lib \
+    cairo \
+    cups-libs \
+    dbus-libs \
+    eudev-libs \
+    expat \
+    flac \
+    gdk-pixbuf \
+    glib \
+    libgcc \
+    libjpeg-turbo \
+    libpng \
+    libwebp \
+    libx11 \
+    libxcomposite \
+    libxdamage \
+    libxext \
+    libxfixes \
+    tzdata \
+    libexif \
+    udev \
+    xvfb \
+    zlib-dev \
+    chromium \
+    chromium-chromedriver
+
+ENV PATH="/usr/bin/chromedriver:${PATH}"
+
+COPY . /test
+
+RUN addgroup -S auth_user_group
+RUN adduser -S authuser -G auth_user_group
+RUN chown -R authuser: /test
+RUN chmod -R u+rwx /test
+RUN mv /test/run-tests.sh /run-tests.sh
+USER authuser
+
+ENTRYPOINT ["/run-tests.sh"]

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -u
+
+ENVIRONMENT=${TEST_ENVIRONMENT:-local}
+export CUCUMBER_FILTER_TAGS="@build-sp"
+
+/test/run-acceptance-tests.sh -r ${ENVIRONMENT}
+return_code=$?
+
+cp -r /test/acceptance-tests/target/cucumber-report/* $(pwd)/results/
+
+exit $return_code

--- a/scripts/database.sh
+++ b/scripts/database.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+ASSUME_ROLE=${ENABLE_CROSSACCOUNT_ROLE:-0}
+if [ "$ASSUME_ROLE" == "1" ]; then
+  output=$(aws sts assume-role --role-arn $CROSSACCOUNT_ROLEARN --role-session-name "dynamo-db-access" --query 'Credentials.[SecretAccessKey,AccessKeyId,SessionToken]' --output text)
+
+  export AWS_ACCESS_KEY_ID=$(echo $output | cut -f2 -d ' ')
+  export AWS_SECRET_ACCESS_KEY=$(echo $output | cut -f1 -d ' ')
+  export AWS_SESSION_TOKEN=$(echo $output | cut -f3 -d ' ')
+fi
+
 function deleteUser() {
   echo "Truncating test user data in user-profile: $1"
   aws dynamodb delete-item \


### PR DESCRIPTION
## What?

- Separate Dockerfile and entrypoint for Secure pipelines deployment
- In `scripts/database.sh`, optional switch to assume role to old account to reset test data, see docs https://govukverify.atlassian.net/wiki/spaces/LO/pages/4485349685/Cross-account+acceptance+tests+run
- (Tech debt reconciliation) Bump aws-actions GHAs to node20 compliant

Issue: [AUT-3549]

## Why?

Auth-deploy-pipeline and sam-deploy-pipeline have some differences in test stage execution logic, sam pipeline being more generic. Changes required in Dockerfile and docker entrypoint script. Though acceptance-tests run from old environments must not break. Hence setup separate dockerfile and entrypoint script. 

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/5169
https://github.com/govuk-one-login/authentication-infrastructure/pull/9
https://github.com/govuk-one-login/devplatform-deploy/pull/2038

[AUT-3549]: https://govukverify.atlassian.net/browse/AUT-3549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ