### PR TITLE
Revert "BAU: Uplift to latest selenium version 4.24.0"

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -16,7 +16,7 @@ def dependencyVersions = [
         cucumber_version: '7.18.1',
         axe_version: '3.0',
         json_version: '20240303',
-        selenium_java_version: '4.24.0',
+        selenium_java_version: '4.23.1',
         rest_assured: '5.5.0'
 ]
 


### PR DESCRIPTION
Reverts govuk-one-login/authentication-acceptance-tests#411

This is so that we can try rolling back to a known good baseline of dependencies before our pipeline acceptance tests became flakey.