### PR TITLE
Revert "BAU - bumped surefire plugin version"

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -21,7 +21,7 @@ def dependencyVersions = [
 ]
 
 dependencies {
-    implementation group: 'org.apache.maven.plugins', name: 'maven-surefire-plugin', version: '3.4.0'
+    implementation group: 'org.apache.maven.plugins', name: 'maven-surefire-plugin', version: '3.2.5'
 
     testImplementation "io.cucumber:cucumber-java:${dependencyVersions.cucumber_version}",
                        "io.cucumber:cucumber-junit:${dependencyVersions.cucumber_version}",


### PR DESCRIPTION
Reverts govuk-one-login/authentication-acceptance-tests#405

This is so that we can try rolling back to a known good baseline of dependencies before our pipeline acceptance tests became flakey.