### PR TITLE
BAU: Reduce the number of checked logouts

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/003_legal_and_policy_pages.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/003_legal_and_policy_pages.feature
@@ -28,4 +28,4 @@ Feature: Legal and policy pages
     Then the user is taken to the "terms of use update" page
     When the user agrees to the updated terms and conditions
     Then the user is returned to the service
-    And the user logs out
+    And the user clicks logout

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/005_auth_app_2fa_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/005_auth_app_2fa_journey.feature
@@ -33,7 +33,7 @@ Feature: Authentication App Journeys
     Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
     When the user enters the security code from the auth app
     Then the user is returned to the service
-    And the user logs out
+    And the user clicks logout
 
   Scenario: User successfully login without 2FA
     Given the user comes from the stub relying party with options: "2fa-off"
@@ -44,7 +44,7 @@ Feature: Authentication App Journeys
     Then the user is taken to the "Enter your password" page
     When the user enters their password
     Then the user is returned to the service
-    And the user logs out
+    And the user clicks logout
 
   Scenario: User signs in auth app without 2FA, then uplifts
     Given the user comes from the stub relying party with options: "2fa-off"

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/006_registration_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/006_registration_journey.feature
@@ -80,7 +80,7 @@ Feature: Registration Journey
     Then the user is taken to the "You’ve created your GOV.UK One Login" page
     When the user clicks the continue button
     Then the user is returned to the service
-    And the user logs out
+    And the user clicks logout
 
 
   @partialRegUser
@@ -92,4 +92,4 @@ Feature: Registration Journey
     Then the user is taken to the "You’ve created your GOV.UK One Login" page
     When the user clicks the continue button
     Then the user is returned to the service
-    And the user logs out
+    And the user clicks logout

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/010_existing_user_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/010_existing_user_journey.feature
@@ -21,7 +21,7 @@ Feature: Login Journey
     Then the user is taken to the "Check your phone" page
     When the user enters the six digit security code from their phone
     Then the user is returned to the service
-    And the user logs out
+    And the user clicks logout
 
   Scenario: Existing user switches content to Welsh
     Given the user comes from the stub relying party with options: "default"
@@ -52,4 +52,4 @@ Feature: Login Journey
     Then the user is taken to the "Enter a security code to continue" page
     When the user enters the six digit security code from their phone
     Then the user is returned to the service
-    And the user logs out
+    And the user clicks logout

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/IPN.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/IPN.feature
@@ -51,7 +51,7 @@ Feature: International Phone Numbers
     Then the user is taken to the "You’ve created your GOV.UK One Login" page
     When the user clicks the continue button
     Then the user is returned to the service
-    And the user logs out
+    And the user clicks logout
 
 #  Scenario: User with an international phone number reports that they did not receive their security code
 #    Given the user comes from the stub relying party with options: "default"

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/Reauthentication.ZZZfeature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/Reauthentication.ZZZfeature
@@ -9,7 +9,7 @@ Feature: Reauthentication of user
     And the user enters the correct password
     And the user enters the six digit security code from their phone
     Then the user is successfully reauthenticated and returned to the service
-    And the user logs out
+    And the user clicks logout
 
   @happy
   Scenario: Auth app user successfully reauthenticates
@@ -19,7 +19,7 @@ Feature: Reauthentication of user
     And the user enters the correct password
     And the user enters the security code from the auth app
     Then the user is successfully reauthenticated and returned to the service
-    And the user logs out
+    And the user clicks logout
 
   @reauth-same-incorrect-emails @AUT-2790
   Scenario: Sms user enters the same incorrect email address (known to One Login) 6 times during reauthentication and gets logged out. Owner of incorrect email is not locked out.
@@ -96,7 +96,7 @@ Feature: Reauthentication of user
     And the user is taken to the "Check your phone" page
     When the sms user changes how they get security codes
     Then the user is successfully reauthenticated and returned to the service
-    And the user logs out
+    And the user clicks logout
 
   # WILL BE REPLACED WITH NEW PROCESS IN V3
   @reauth-change-security-code-method-to-sms
@@ -108,7 +108,7 @@ Feature: Reauthentication of user
     And the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
     When the auth app user changes how they get security codes
     Then the user is successfully reauthenticated and returned to the service
-    And the user logs out
+    And the user clicks logout
 
   # WILL BE REPLACED WITH NEW PROCESS IN V3
   @reauth-pw-reset
@@ -119,4 +119,4 @@ Feature: Reauthentication of user
     And the user is taken to the "Enter your password" page
     When the sms user changes their password during reauthentication
     Then the user is successfully reauthenticated and returned to the service
-    And the user logs out
+    And the user clicks logout

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/account_interventions.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/account_interventions.feature
@@ -239,7 +239,7 @@ Feature: Account interventions
 #    The test needs to stop here in Build, due to there being static data in the AIS stub the reset pw flag is not removed and so the correct path is not followed
 #    When the user enters valid new password and correctly retypes it
 #    Then the user is returned to the service
-#    And the user logs out
+#    And the user clicks logout
 
   @reset_password
   Scenario: Auth app user forced to reset their password when a password reset intervention has been placed on their account
@@ -259,7 +259,7 @@ Feature: Account interventions
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
     Then the user is returned to the service
-    And the user logs out
+    And the user clicks logout
 
   @reset_password
   Scenario: Auth app user with a password reset intervention on their account is able to use the I have forgotten my password link
@@ -277,7 +277,7 @@ Feature: Account interventions
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
     Then the user is returned to the service
-    And the user logs out
+    And the user clicks logout
 
   @reset_password
   Scenario: Sms user is forced to reset their password when they have a password reset intervention on their account and their existing password is on top 100k password list
@@ -295,7 +295,7 @@ Feature: Account interventions
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
     Then the user is returned to the service
-    And the user logs out
+    And the user clicks logout
 
   @reset_password
   Scenario: Auth app user with outdated terms and conditions cannot log in when they have a password reset intervention on their account
@@ -317,7 +317,7 @@ Feature: Account interventions
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
     Then the user is returned to the service
-    And the user logs out
+    And the user clicks logout
 
   @reset_password
   Scenario: Auth app user cannot change the way they get security codes when they have a password reset intervention on their account
@@ -340,7 +340,7 @@ Feature: Account interventions
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
     Then the user is returned to the service
-    And the user logs out
+    And the user clicks logout
 
   @locked @suspended @reset_password
   Scenario: Auth app user can log in when their One Login account intervention has been removed
@@ -354,4 +354,4 @@ Feature: Account interventions
     Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
     When the user enters the security code from the auth app
     Then the user is returned to the service
-    And the user logs out
+    And the user clicks logout

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/account_recovery.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/account_recovery.feature
@@ -34,7 +34,7 @@ Feature: Account recovery
     Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
     When the user enters the security code from the auth app
     Then the user is returned to the service
-    And the user logs out
+    And the user clicks logout
 
 
   Scenario: An auth app user can change how they get security codes and log in with new method
@@ -71,4 +71,4 @@ Feature: Account recovery
     Then the user is taken to the "Check your phone" page
     When the user enters the six digit security code from their phone
     Then the user is returned to the service
-    And the user logs out
+    And the user clicks logout


### PR DESCRIPTION
## What?

Previously, we checked that log-out had succeeded for almost every logout attempt. Now, use the lazy "click the box and run away" method unless we are reusing the browser session.

As we are currently having intermittent issues with confirming logout, this will reduce the number of times we could possibly encounter that situation.