### PR TITLE
AUT-3685: Update strings to reflect content update

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/ReenterYourSignInDetailsToContinuePage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/ReenterYourSignInDetailsToContinuePage.java
@@ -5,7 +5,7 @@ import org.openqa.selenium.By;
 public class ReenterYourSignInDetailsToContinuePage extends BasePage {
     By emailField = By.id("email");
     public static final String REAUTH_SIGN_IN_PAGE_HEADER =
-            "Re-enter your sign-in details to continue";
+            "Enter your sign in details for GOV.UK One Login again";
 
     public void enterEmailAddressAndContinue(String emailAddress) {
         waitForPage();

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CrossPageFlows.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CrossPageFlows.java
@@ -109,7 +109,7 @@ public class CrossPageFlows extends BasePage {
         waitForPageLoad("Example - GOV.UK - User Info");
         String idToken = userInformationPage.getIdToken();
         rpStubPage.reauthRequired(idToken);
-        waitForPageLoad("Re-enter your sign-in details to continue");
+        waitForPageLoad("Enter your sign in details for GOV.UK One Login again");
         // enter original email address
         reenterYourSignInDetailsToContinuePage.enterEmailAddressAndContinue(
                 System.getenv().get(userEmailAddress));


### PR DESCRIPTION
## What?

Updates the acceptance tests to reflect content update.

## Why?

The re-auth page asking users to re-enter their sign-in details page content is being updated. 

## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/2057 introduces the content update this change relates to