### PR TITLE
BAU: Clear cookies to simulate logout

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
@@ -77,6 +77,11 @@ public class CommonStepDef extends BasePage {
         waitForPageLoad("Signed out");
     }
 
+    @And("the users cookies are cleared")
+    public void theUsersCookiesAreCleared() {
+        Driver.get().manage().deleteAllCookies();
+    }
+
     @Then("the user is shown an error message")
     public void theUserIsShownAnErrorMessageOnTheEnterEmailPage() {
         assertTrue(isErrorSummaryDisplayed());

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/005_auth_app_2fa_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/005_auth_app_2fa_journey.feature
@@ -21,7 +21,8 @@ Feature: Authentication App Journeys
     And the user is taken to the "You’ve created your GOV.UK One Login" page
     When the user clicks the continue button
     Then the user is returned to the service
-    And the user logs out
+    And the user clicks logout
+    And the users cookies are cleared
 
     When the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create your GOV.UK One Login or sign in" page


### PR DESCRIPTION


## What?

Clear cookies to simulate logout.

## Why?

Some tests are getting stuck waiting for logout to complete on the RP stub in the pipeline, which is causing tests to fail.  A workaround was to stop waiting for logout to complete as this was the last step in most tests.  However, where there was a dependency on logout completing for the next scenario to continue this could not be done.

Instead do not wait for logout to complete before the next step, but clear cookies so that the user's session is effectively cleared, and they will start the journey again.


## Related PRs

#418 