### PR TITLE
BAU: Don't run spotless when testing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,9 +17,6 @@ repos:
         types_or:
           - java
           - groovy
-          - yaml
-          - markdown
-          - json
         pass_filenames: false
         require_serial: true
 
@@ -27,6 +24,20 @@ repos:
     rev: v1.92.1
     hooks:
       - id: terraform_fmt
+
+  - repo: local
+    hooks:
+      - id: shfmt
+        name: shfmt (shell scripts)
+        language: golang
+        additional_dependencies:
+          - mvdan.cc/sh/v3/cmd/shfmt@v3.8.0
+        entry: shfmt -w -s -l
+        types:
+          - file
+          - shell
+        exclude_types:
+          - zsh
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: a23f6b85d0fdd5bb9d564e2579e678033debbdff # v0.10.0.1 # pragma: allowlist secret
@@ -40,21 +51,3 @@ repos:
     rev: v1.7.0
     hooks:
       - id: actionlint
-
-  - repo: local
-    hooks:
-      - id: shfmt
-        name: shfmt (shell scripts)
-        language: golang
-        additional_dependencies:
-          - mvdan.cc/sh/v3/cmd/shfmt@v3.8.0
-        entry: shfmt
-        types:
-          - file
-          - shell
-        exclude_types:
-          - zsh
-        args:
-          - -w # write
-          - -s # simplify
-          - -l # list files that differ

--- a/build.gradle
+++ b/build.gradle
@@ -32,11 +32,6 @@ spotless {
         target "**/*.gradle"
         greclipse().configFile("tools/spotless-gradle.properties")
     }
-
-    format 'styling', {
-        target '**/*.md', '**/*.yml', '**/*.yaml', '**/*.json'
-        prettier()
-    }
 }
 
 repositories {

--- a/run-acceptance-tests-against-dev-env.sh
+++ b/run-acceptance-tests-against-dev-env.sh
@@ -63,7 +63,7 @@ if [ -d "$TESTDIR" ]; then
   cd $TESTDIR
 fi
 
-./gradlew clean spotlessApply build -x :acceptance-tests:test
+./gradlew clean build -x :acceptance-tests:test -x spotlessApply -x spotlessCheck
 
 build_and_test_exit_code=$?
 if [ ${build_and_test_exit_code} -ne 0 ]; then
@@ -82,7 +82,7 @@ set -o allexport && source .env && set +o allexport
 
 ./reset-test-data.sh -l "${ENVIRONMENT}"
 
-./gradlew cucumber
+./gradlew cucumber -x spotlessApply -x spotlessCheck
 
 build_and_test_exit_code=$?
 

--- a/run-acceptance-tests-against-dev-env.sh
+++ b/run-acceptance-tests-against-dev-env.sh
@@ -5,8 +5,8 @@ set -eu
 envvalue=("sandpit" "authdev1" "authdev2" "dev")
 
 select word in "${envvalue[@]}"; do
-  if [[ -z "$word" ]]; then
-    printf '"%s" is not a valid choice\n' "$REPLY" >&2
+  if [[ -z ${word} ]]; then
+    printf '"%s" is not a valid choice\n' "${REPLY}" >&2
   else
     user_in="$((REPLY - 1))"
     break
@@ -22,12 +22,11 @@ for ((i = 0; i < ${#envvalue[@]}; ++i)); do
   fi
 done
 
-
 DOCKER_BASE=docker-compose
 SSM_VARS_PATH="/acceptance-tests/$ENVIRONMENT"
 TESTDIR="/test"
 
-echo "Running in $ENVIRONMENT environment..."
+echo "Running in ${ENVIRONMENT} environment..."
 
 function start_docker_services() {
   ${DOCKER_BASE} up --build -d --wait --no-deps --quiet-pull "$@"
@@ -41,10 +40,10 @@ function get_env_vars_from_SSM() {
 
   echo "Getting environment variables from SSM ... "
 
-  VARS="$(aws ssm get-parameters-by-path --with-decryption --path $SSM_VARS_PATH | jq -r '.Parameters[] | @base64')"
+  VARS="$(aws ssm get-parameters-by-path --with-decryption --path "${SSM_VARS_PATH}" | jq -r '.Parameters[] | @base64')"
   for VAR in $VARS; do
-    VAR_NAME="$(echo ${VAR} | base64 -d | jq -r '.Name / "/" | .[3]')"
-    export "$VAR_NAME"="$(echo ${VAR} | base64 -d | jq -r '.Value')"
+    VAR_NAME="$(echo "${VAR}" | base64 -d | jq -r '.Name / "/" | .[3]')"
+    export "$VAR_NAME"="$(echo "${VAR}" | base64 -d | jq -r '.Value')"
   done
   echo "Exported SSM parameters completed."
 }
@@ -60,7 +59,7 @@ function export_selenium_config() {
 echo -e "Building di-authentication-acceptance-tests..."
 
 if [ -d "$TESTDIR" ]; then
-  echo "Changing to $TESTDIR"
+  echo "Changing to ${TESTDIR}"
   cd $TESTDIR
 fi
 
@@ -78,12 +77,10 @@ start_docker_services selenium-firefox selenium-chrome
 
 export_selenium_config
 
+# shellcheck source=/dev/null
 set -o allexport && source .env && set +o allexport
 
-
-
-./reset-test-data.sh -l "$ENVIRONMENT"
-
+./reset-test-data.sh -l "${ENVIRONMENT}"
 
 ./gradlew cucumber
 

--- a/run-acceptance-tests.sh
+++ b/run-acceptance-tests.sh
@@ -2,11 +2,10 @@
 
 set -eu
 
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
 
-ENVIRONMENT=${2:-local}
+ENVIRONMENT="${2:-local}"
 
-DOCKER_BASE=docker-compose
 SSM_VARS_PATH="/acceptance-tests/$ENVIRONMENT"
 TESTDIR="/test"
 
@@ -14,23 +13,23 @@ EXPORT_ENV=0
 LOCAL=0
 while getopts "lre" opt; do
   case ${opt} in
-  l)
-    LOCAL=1
-    ;;
-  r)
-    LOCAL=0
-    ;;
-  e)
-    EXPORT_ENV=1
-    ;;
-  *)
-    usage
-    exit 1
-    ;;
+    l)
+      LOCAL=1
+      ;;
+    r)
+      LOCAL=0
+      ;;
+    e)
+      EXPORT_ENV=1
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
   esac
 done
 
-echo "Running in $ENVIRONMENT environment..."
+echo "Running in ${ENVIRONMENT} environment..."
 
 function get_env_vars_from_SSM() {
 
@@ -45,17 +44,17 @@ function get_env_vars_from_SSM() {
       echo "#"
       echo "# Rename to .env to use for testing"
       echo "#"
-    } >>$envfile
+    } >> "${envfile}"
   fi
 
-  VARS="$(aws ssm get-parameters-by-path --with-decryption --path $SSM_VARS_PATH | jq -r '.Parameters[] | @base64')"
+  VARS="$(aws ssm get-parameters-by-path --with-decryption --path "${SSM_VARS_PATH}" | jq -r '.Parameters[] | @base64')"
   for VAR in $VARS; do
-    VAR_NAME="$(echo ${VAR} | base64 -d | jq -r '.Name / "/" | .[3]')"
-    VAR_NAME_VALUE=$VAR_NAME="$(echo ${VAR} | base64 -d | jq -r '.Value')"
+    VAR_NAME="$(echo "${VAR}" | base64 -d | jq -r '.Name / "/" | .[3]')"
+    VAR_NAME_VALUE=$VAR_NAME="$(echo "${VAR}" | base64 -d | jq -r '.Value')"
     if [ $EXPORT_ENV == "1" ]; then
-      echo "$VAR_NAME_VALUE" >>$envfile
+      echo "$VAR_NAME_VALUE" >> "${envfile}"
     fi
-    export "$VAR_NAME"="$(echo ${VAR} | base64 -d | jq -r '.Value')"
+    export "$VAR_NAME"="$(echo "${VAR}" | base64 -d | jq -r '.Value')"
   done
   echo "Exported SSM parameters completed."
 
@@ -75,7 +74,7 @@ function export_selenium_config() {
 echo -e "Building di-authentication-acceptance-tests..."
 
 if [ -d "$TESTDIR" ]; then
-  echo "Changing to $TESTDIR"
+  echo "Changing to ${TESTDIR}"
   cd $TESTDIR
 fi
 
@@ -101,9 +100,9 @@ else
 fi
 
 if [ $LOCAL == "1" ]; then
-  ./reset-test-data.sh -l $ENVIRONMENT
+  ./reset-test-data.sh -l "${ENVIRONMENT}"
 else
-  ./reset-test-data.sh -r $ENVIRONMENT
+  ./reset-test-data.sh -r "${ENVIRONMENT}"
 fi
 
 ./gradlew cucumber

--- a/run-acceptance-tests.sh
+++ b/run-acceptance-tests.sh
@@ -78,7 +78,7 @@ if [ -d "$TESTDIR" ]; then
   cd $TESTDIR
 fi
 
-./gradlew clean spotlessApply build -x :acceptance-tests:test
+./gradlew clean build -x :acceptance-tests:test -x spotlessApply -x spotlessCheck
 
 build_and_test_exit_code=$?
 if [ ${build_and_test_exit_code} -ne 0 ]; then
@@ -105,7 +105,7 @@ else
   ./reset-test-data.sh -r "${ENVIRONMENT}"
 fi
 
-./gradlew cucumber
+./gradlew cucumber -x spotlessApply -x spotlessCheck
 
 build_and_test_exit_code=$?
 


### PR DESCRIPTION
## What

Explicitely forbid spotless from running in `run-acceptance-tests*`.

It should already be done by this point, and spotless seems sad now.

## How to review

Code review should do it

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

