### PR TITLE
BAU: fix retry methodology

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/RpStubStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/RpStubStepDef.java
@@ -26,13 +26,13 @@ public class RpStubStepDef extends BasePage {
     }
 
     public void doRpStubAndWaitForSignInPage(String rpStubOptions, Throwable lastException) {
-        Integer attempt = retryHelper.getAndIncrement("come-from-rp-stub");
-        if (attempt > RETRY_LIMIT) {
-            throw new RPStubRetryException(lastException);
-        }
-        if (attempt > 1) {
+        if (lastException != null) {
+            Integer currentRetries = retryHelper.getAndIncrement("come-from-rp-stub");
+            if (currentRetries > RETRY_LIMIT) {
+                throw new RPStubRetryException(lastException);
+            }
             Driver.get().manage().deleteAllCookies();
-            System.out.printf("Retrying RP stub, attempt %s%n", attempt);
+            System.out.printf("Retrying RP stub, retry %s of %s%n", currentRetries, RETRY_LIMIT);
         }
 
         try {


### PR DESCRIPTION
## What

Previously, the retry counter would increase *every time* `doRpStubAndWaitForSignInPage()` was called. Obviously this means that after 5 calls to the method, it has always exceeded the limit. Essentially it acted as a call counter.

Now, we don't increment the retry counter *until* the function has been called with a throwable, ie. we don't ever retry until it's previously failed. ie. we actually count retries, not just tries.