### PR TITLE
BAU: Don't delete cookies when retrying the stub

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/RpStubStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/RpStubStepDef.java
@@ -5,7 +5,6 @@ import io.cucumber.java.en.When;
 import org.openqa.selenium.WebDriverException;
 import uk.gov.di.test.pages.BasePage;
 import uk.gov.di.test.pages.RpStubPage;
-import uk.gov.di.test.utils.Driver;
 import uk.gov.di.test.utils.RetryHelper;
 import uk.gov.di.test.utils.SessionContextExceptions;
 
@@ -31,7 +30,6 @@ public class RpStubStepDef extends BasePage {
             if (currentRetries > RETRY_LIMIT) {
                 throw new RPStubRetryException(lastException);
             }
-            Driver.get().manage().deleteAllCookies();
             System.out.printf("Retrying RP stub, retry %s of %s%n", currentRetries, RETRY_LIMIT);
         }
 


### PR DESCRIPTION
## What

Cookies were being deleted before out of an abundance of caution.

This is actually disruptive in the case of SSO uplift - we need
to keep the existing session in place.

In theory, if we are retrying the RP stub, it means that no
session stuff has actually happened at that point, so there's no
actual need to clear them when retrying.

This has the side effect of fixing the uplift edge case without
writing any more java.
