### PR TITLE
ATO-1013: add bsid cookie to OneLoginSession

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/utils/OneLoginSession.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/utils/OneLoginSession.java
@@ -10,6 +10,7 @@ public class OneLoginSession {
     private String clientSessionID;
     private String persistentSessionId;
     private String languageFromCookie;
+    private String browserSessionId;
 
     public OneLoginSession(Set<Cookie> cookies) {
         for (Cookie cookie : cookies) {
@@ -25,6 +26,9 @@ public class OneLoginSession {
                 case "lng":
                     languageFromCookie = cookie.getValue();
                     break;
+                case "bsid":
+                    browserSessionId = cookie.getValue();
+                    break;
                 default:
                     break;
             }
@@ -37,6 +41,7 @@ public class OneLoginSession {
         json.put("clientSessionId", clientSessionID);
         json.put("persistentSessionId", persistentSessionId);
         json.put("languageFromCookie", languageFromCookie.toUpperCase());
+        json.put("browserSessionId", browserSessionId);
         return json;
     }
 }


### PR DESCRIPTION
## What
Adds the new "bsid" cookie to the OneLoginSession. As far as I can tell, this class is only used for logging on error. 

There are no tests which close and reopen the browser (which would delete this cookie and sign a user out), so I believe this is the only change needed.

## How to review
1. Code Review
