### PR TITLE
BAU: Group dependabot PRs to reduce the number of PRs.  Initially jus…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,11 @@ updates:
       prefix: BAU
   - package-ecosystem: github-actions
     directory: "/"
-    open-pull-requests-limit: 100
+    open-pull-requests-limit: 10
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
     target-branch: main
     schedule:
       interval: weekly


### PR DESCRIPTION
…t group the github-actions.  Leaving the number of open pull requests above 1 to ensure we don't having pending changes that don't have a PR.

## What

<!-- Describe what you have changed and why -->

Update to dependabot rules to instruct it to create a PR with all available changes on it each time it scans the repo.  The number of allowed open PRs is set to 10 so that we will always have PRs for changes rather than queueing them until the PR for that group is closed. 

## How to review

1. Code Review

We will need to observe the behaviour once its merged to main and see what happens on he next weekly dependabot scan.

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
