### PR TITLE
BAU: Change the group name so the titles of the PRs dependabot create…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,18 +6,22 @@ updates:
       interval: daily
       time: "03:00"
     open-pull-requests-limit: 10
+    groups:
+      gradle-all-dependencies:
+        patterns:
+          - "*"
     target-branch: main
     commit-message:
       prefix: BAU
   - package-ecosystem: github-actions
     directory: "/"
+    schedule:
+      interval: weekly
     open-pull-requests-limit: 10
     groups:
-      all-dependencies:
+      gha-all-dependencies:
         patterns:
           - "*"
     target-branch: main
-    schedule:
-      interval: weekly
     commit-message:
       prefix: BAU


### PR DESCRIPTION
…s are more informative.  Added a group for gradle package ecosystem.

## What

<!-- Describe what you have changed and why -->
More dependabot config changes.  The previous change to add a new group for the GHAs didn't produce very informative PR titles.  Added a new group for the gradle ecosystem to trial how that works as well.
## How to review
1. Code Review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
