### PR TITLE
BAU: ensure we don't call methods on null

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/utils/OneLoginSession.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/utils/OneLoginSession.java
@@ -36,11 +36,12 @@ public class OneLoginSession {
     }
 
     public JSONObject toJSONObject() {
+        var language = languageFromCookie == null ? "MISSING" : languageFromCookie.toUpperCase();
         JSONObject json = new JSONObject();
         json.put("sessionId", sessionId);
         json.put("clientSessionId", clientSessionID);
         json.put("persistentSessionId", persistentSessionId);
-        json.put("languageFromCookie", languageFromCookie.toUpperCase());
+        json.put("languageFromCookie", language);
         json.put("browserSessionId", browserSessionId);
         return json;
     }


### PR DESCRIPTION
This seems to be masking other test failures
