### PR TITLE
Revert "ATO-1013: add bsid cookie to OneLoginSession"

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/utils/OneLoginSession.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/utils/OneLoginSession.java
@@ -10,7 +10,6 @@ public class OneLoginSession {
     private String clientSessionID;
     private String persistentSessionId;
     private String languageFromCookie;
-    private String browserSessionId;
 
     public OneLoginSession(Set<Cookie> cookies) {
         for (Cookie cookie : cookies) {
@@ -26,9 +25,6 @@ public class OneLoginSession {
                 case "lng":
                     languageFromCookie = cookie.getValue();
                     break;
-                case "bsid":
-                    browserSessionId = cookie.getValue();
-                    break;
                 default:
                     break;
             }
@@ -42,7 +38,6 @@ public class OneLoginSession {
         json.put("clientSessionId", clientSessionID);
         json.put("persistentSessionId", persistentSessionId);
         json.put("languageFromCookie", language);
-        json.put("browserSessionId", browserSessionId);
         return json;
     }
 }


### PR DESCRIPTION
This reverts commit 2d3a1f22c278dee570d249cc504b9584a2f3670a, PR https://github.com/govuk-one-login/authentication-acceptance-tests/pull/438

## What
This was previously added as the bsid cookie was going to be on the `account.gov.uk` domain, but this changed to be `oidc.account.gov.uk`, meaning on none of these pages would the `bsid` cookie be accessible. 

## How to review

1. Code Review
