### PR TITLE
BAU: Add instructions to readme for generating env files for different envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ This is the default option if running the tests using `./run-acceptance-tests.sh
 
 The configuration provided will connect to the build environment.
 
+If you need to run against another environment, use the 's' flag e.g. `./run-acceptance-tests.sh -s sandpit`.
+
+Note that you need to export the aws profile required before running this, e.g. `export AWS_PROFILE=[some-aws-profile-with-sufficient-access-to-the-selected-env]`
+
 #### Local .env Configuration
 
 To create a .env file based on the values in AWS SSM Parameter Store:


### PR DESCRIPTION
## What

Readme updates to explain how to use aws config from the parameter store to run the acceptance tests locally against envs other than build.

## How to review

1. Code Review