### PR TITLE
AUT-3802: Fix failing reauthentication test.

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/ReenterYourSignInDetailsToContinuePage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/ReenterYourSignInDetailsToContinuePage.java
@@ -2,9 +2,15 @@ package uk.gov.di.test.pages;
 
 import org.openqa.selenium.By;
 import uk.gov.di.test.services.UserLifecycleService;
+import uk.gov.di.test.step_definitions.World;
 
 public class ReenterYourSignInDetailsToContinuePage extends BasePage {
     UserLifecycleService userLifecycleService = UserLifecycleService.getInstance();
+    World world;
+
+    public ReenterYourSignInDetailsToContinuePage(World world) {
+        this.world = world;
+    }
 
     By emailField = By.id("email");
     public static final String REAUTH_SIGN_IN_PAGE_HEADER =
@@ -16,13 +22,18 @@ public class ReenterYourSignInDetailsToContinuePage extends BasePage {
         findAndClickContinue();
     }
 
+    public void enterAnotherUsersEmailAddressNumberOfTime(int numberOfTimes) {
+        for (int i = 1; i <= numberOfTimes; i++) {
+            enterEmailAddressAndContinue(world.getOtherUserProfile().getEmail());
+            System.out.println("Wrong email entry count: " + i);
+        }
+    }
+
     public void enterSameIncorrectEmailAddressesNumberOfTimes(Integer numberOfTimes) {
-        throw new RuntimeException("Need to implement new-style user flows for this");
-        //        for (int index = 0; index < numberOfTimes; index++) {
-        //            int count = index + 1;
-        //            enterEmailAddressAndContinue(System.getenv().get("TEST_USER_REAUTH_SMS_9"));
-        //            System.out.println("Wrong email entry count: " + count);
-        //        }
+        for (int i = 1; i <= numberOfTimes; i++) {
+            enterEmailAddressAndContinue(world.getUserEmailAddress());
+            System.out.println("Wrong email entry count: " + i);
+        }
     }
 
     public void enterDifferentIncorrectEmailAddressesNumberOfTimes(Integer numberOfTimes) {

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
@@ -22,9 +22,11 @@ public class CommonStepDef extends BasePage {
     public CreateOrSignInPage createOrSignInPage = new CreateOrSignInPage();
     public StubUserInfoPage stubUserInfoPage = StubUserInfoPage.getStubUserInfoPage();
     StubStartPage stubStartPage = StubStartPage.getStubStartPage();
+    private final World world;
 
     public CommonStepDef(World world) {
         this.crossPageFlows = new CrossPageFlows(world);
+        this.world = world;
     }
 
     String idToken;
@@ -111,6 +113,14 @@ public class CommonStepDef extends BasePage {
     @And("the user is not blocked from signing in")
     public void theUserIsAlreadySignedIn() {
         crossPageFlows.successfulSignIn();
+    }
+
+    @When("the other User attempts to use OneLogin")
+    public void theOtherUserAttemptsToUseOneLogin() {
+        world.userProfile = world.getOtherUserProfile();
+        world.userCredentials = world.getOtherUserCredentials();
+        world.userInterventions = world.getOtherUserInterventions();
+        world.setUserPassword(world.getOtherUserPassword());
     }
 
     @When("the RP requires the user to reauthenticate")

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CrossPageFlows.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CrossPageFlows.java
@@ -46,12 +46,12 @@ public class CrossPageFlows extends BasePage {
     public ResetYourPasswordPage resetYourPasswordPage = new ResetYourPasswordPage();
     public CreateYourPasswordPage createYourPasswordPage = new CreateYourPasswordPage();
     public StubUserInfoPage stubUserInfoPage = StubUserInfoPage.getStubUserInfoPage();
-    public ReenterYourSignInDetailsToContinuePage reenterYourSignInDetailsToContinuePage =
-            new ReenterYourSignInDetailsToContinuePage();
+    public ReenterYourSignInDetailsToContinuePage reenterYourSignInDetailsToContinuePage;
 
     public CrossPageFlows(World world) {
         this.world = world;
         this.enterYourPasswordPage = new EnterYourPasswordPage(world);
+        reenterYourSignInDetailsToContinuePage = new ReenterYourSignInDetailsToContinuePage(world);
     }
 
     public void requestPhoneSecurityCodeResendNumberOfTimes(
@@ -191,7 +191,6 @@ public class CrossPageFlows extends BasePage {
     }
 
     public void smsUserChangeHowGetSecurityCodesToAuthApp() {
-        String authAppSecretKey;
         selectLinkByText("Problems with the code?");
         selectLinkByText("change how you get security codes");
         waitForPageLoad("Check your email");

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/LoginStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/LoginStepDef.java
@@ -271,7 +271,7 @@ public class LoginStepDef extends BasePage {
         reenterYourSignInDetailsToContinuePage.enterSameIncorrectEmailAddressesNumberOfTimes(1);
     }
 
-    @When("the user enters the same incorrect email address for reauth a further {int} times")
+    @When("the user enters an incorrect email address for reauth {int} times")
     public void theUserEntersDifferentEmailAddressXTimes(Integer attemptCount) {
         reenterYourSignInDetailsToContinuePage.enterSameIncorrectEmailAddressesNumberOfTimes(
                 attemptCount);

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/LoginStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/LoginStepDef.java
@@ -57,8 +57,7 @@ public class LoginStepDef extends BasePage {
     public EnterYourEmailAddressPage enterYourEmailAddressPage = new EnterYourEmailAddressPage();
     public SetUpAnAuthenticatorAppPage setUpAnAuthenticatorAppPage =
             new SetUpAnAuthenticatorAppPage();
-    public ReenterYourSignInDetailsToContinuePage reenterYourSignInDetailsToContinuePage =
-            new ReenterYourSignInDetailsToContinuePage();
+    public ReenterYourSignInDetailsToContinuePage reenterYourSignInDetailsToContinuePage;
     public EnterThe6DigitSecurityCodeShownInYourAuthenticatorAppPage
             enterThe6DigitSecurityCodeShownInYourAuthenticatorAppPage =
                     new EnterThe6DigitSecurityCodeShownInYourAuthenticatorAppPage();
@@ -68,6 +67,7 @@ public class LoginStepDef extends BasePage {
         this.world = world;
         this.enterYourPasswordPage = new EnterYourPasswordPage(world);
         this.crossPageFlows = new CrossPageFlows(world);
+        reenterYourSignInDetailsToContinuePage = new ReenterYourSignInDetailsToContinuePage(world);
     }
 
     @When("the user enters their password which is on the top 100k password list")
@@ -96,6 +96,12 @@ public class LoginStepDef extends BasePage {
     public void userEntersTheirEmailAddressForReauth() {
         reenterYourSignInDetailsToContinuePage.enterEmailAddressAndContinue(
                 world.getUserEmailAddress());
+    }
+
+    @When("the logged in user enters the other users email address")
+    public void userEntersAnotherUsersEmailAddressForReauth() {
+        reenterYourSignInDetailsToContinuePage.enterEmailAddressAndContinue(
+                world.getOtherUserProfile().getEmail());
     }
 
     @And("user enters the same email address {string} for reauth as they used for login")
@@ -268,6 +274,13 @@ public class LoginStepDef extends BasePage {
     @When("the user enters the same incorrect email address for reauth a further {int} times")
     public void theUserEntersDifferentEmailAddressXTimes(Integer attemptCount) {
         reenterYourSignInDetailsToContinuePage.enterSameIncorrectEmailAddressesNumberOfTimes(
+                attemptCount);
+    }
+
+    @When(
+            "the logged-in User enters the other Users email address for reauth a further {int} times")
+    public void theUserEntersAnotherUsersEmailAddressXTimes(Integer attemptCount) {
+        reenterYourSignInDetailsToContinuePage.enterAnotherUsersEmailAddressNumberOfTime(
                 attemptCount);
     }
 

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/RpStubStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/RpStubStepDef.java
@@ -43,6 +43,7 @@ public class RpStubStepDef extends BasePage {
     }
 
     @Then("the user is forcibly logged out")
+    @Then("the logged-in User is forcibly logged out")
     public void theUserIsLoggedOut() {
         waitForThisText("Error in Callback");
         waitForThisText("Error: login_required");

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/UserLifecycleStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/UserLifecycleStepDef.java
@@ -57,6 +57,28 @@ public class UserLifecycleStepDef {
         }
     }
 
+    @And("Another User with {mfaMethod} exists")
+    public void anotherUserExists(String mfaMethod) {
+        world.setOtherUserProfile(userLifecycleService.buildNewUserProfile());
+        world.setOtherUserPassword(generateValidPassword());
+        switch (mfaMethod) {
+            case "no":
+                break;
+            case "SMS":
+                userLifecycleService.updateUserMfaSms(world.getOtherUserProfile());
+                break;
+            case "App":
+                userLifecycleService.updateUserMfaApp(world.getOtherUserCredentials());
+                break;
+            default:
+                throw new RuntimeException("Invalid MFA Method");
+        }
+        userLifecycleService.putUserProfileToDynamodb(world.getOtherUserProfile());
+        world.setOtherUserCredentials(
+                userLifecycleService.buildNewUserCredentialsAndPutToDynamodb(
+                        world.getOtherUserProfile(), world.getOtherUserPassword()));
+    }
+
     @And("the user has not yet accepted the latest terms and conditions")
     public void theUserHasNotYetAcceptedTheLatestTermsAndConditions() {
         userLifecycleService.updateUserTermsAndConditions(

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/World.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/World.java
@@ -17,8 +17,44 @@ public class World {
     public UserProfile userProfile;
     public UserCredentials userCredentials;
     public UserInterventions userInterventions;
-
     private String userPassword;
+
+    private UserProfile otherUserProfile;
+    private UserCredentials otherUserCredentials;
+    private UserInterventions otherUserInterventions;
+    private String otherUserPassword;
+
+    public UserCredentials getOtherUserCredentials() {
+        return otherUserCredentials;
+    }
+
+    public void setOtherUserCredentials(UserCredentials otherUserCredentials) {
+        this.otherUserCredentials = otherUserCredentials;
+    }
+
+    public UserInterventions getOtherUserInterventions() {
+        return otherUserInterventions;
+    }
+
+    public void setOtherUserInterventions(UserInterventions otherUserInterventions) {
+        this.otherUserInterventions = otherUserInterventions;
+    }
+
+    public String getOtherUserPassword() {
+        return otherUserPassword;
+    }
+
+    public void setOtherUserPassword(String otherUserPassword) {
+        this.otherUserPassword = otherUserPassword;
+    }
+
+    public UserProfile getOtherUserProfile() {
+        return otherUserProfile;
+    }
+
+    public void setOtherUserProfile(UserProfile otherUserProfile) {
+        this.otherUserProfile = otherUserProfile;
+    }
 
     public String getUserPassword() {
         return userPassword;

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/Reauthentication.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/Reauthentication.feature
@@ -22,16 +22,22 @@ Feature: Reauthentication of user
     And the user enters the security code from the auth app
     Then the user is successfully reauthenticated and returned to the service
 
-#  @reauth-same-incorrect-emails @AUT-2790
-#  Scenario: Sms user enters the same incorrect email address (known to One Login) 6 times during reauthentication and gets logged out. Owner of incorrect email is not locked out.
-#    Given the "sms" user "TEST_USER_REAUTH_SMS_2" is already signed in to their One Login account
-#    And the RP requires the user to reauthenticate
-#    When the user enters an incorrect email address at reauth that is known to One Login
-#    Then the "Enter the same email address you used to sign in" error message is displayed
-#    When the user enters the same incorrect email address for reauth a further 5 times
-#    Then the user is forcibly logged out
-#    And the owner of the incorrect email address is not blocked from signing in
-#    And the owner of the incorrect email address is not blocked from reauthenticating
+  @reauth-same-incorrect-emails @AUT-2790
+  Scenario: Sms user enters the same incorrect email address (known to One Login) 6 times during reauthentication and gets logged out. Owner of incorrect email is not locked out.
+    Given a user with SMS MFA exists
+    And the user is already signed in to their One Login account
+    And the RP requires the user to reauthenticate
+    And Another User with SMS exists
+
+    When the logged in user enters the other users email address
+    Then the "Enter the same email address you used to sign in" error message is displayed
+
+    When the logged-in User enters the other Users email address for reauth a further 5 times
+    Then the logged-in User is forcibly logged out
+
+    When the other User attempts to use OneLogin
+    Then the user is not blocked from signing in
+    And the user is not blocked from reauthenticating
 
   @reauth-different-incorrect-emails @AUT-2790
   Scenario: Sms user enters 6 different incorrect email addresses (not known to One Login) during reauthentication and gets logged out. Original user is not locked out.

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/Reauthentication.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/Reauthentication.feature
@@ -109,12 +109,14 @@ Feature: Reauthentication of user
   #Silent log in support for multiple RPs re-authenticating (This is only relevant for multiple tabs)
 #  @reauth-multiple-rp-tab @AUT-3529 @AUT-3530
 #  Scenario: Sms user verify that silent login does not reset the counts of failed credential entry for the re-authentication journey [invalid email]
-#    Given the "sms" user "TEST_USER_REAUTH_SMS_2" is already signed in to their One Login account
-#    And the RP requires the user to reauthenticate
-#    When the user enters the same incorrect email address for reauth a further 5 times
-#    And user opens up new tab in the same browser and performs a silent log in and navigate back to the first tab
-#    When the user enters the same incorrect email address for reauth a further 1 times
-#    Then the user is returned to the service
+#    Given a user with SMS MFA exists
+#    And the user is already signed in to their One Login account
+#
+#    Given the RP requires the user to reauthenticate
+#    When the user enters an incorrect email address for reauth 5 times
+#    And the user opens up new tab in the same browser, performs a silent log in and switches back to the first tab
+#    When the user enters an incorrect email address for reauth 1 times
+#    Then the user is forcibly logged out
 
 
   @reauth-multiple-rp-tab @AUT-3529 @AUT-3530


### PR DESCRIPTION
 Introduce the concept of a second User whose details can be used by the logged-in User.  The second User details can then be used to check that their misuse by another User does not prevent them from logging in or re-authenticating.

## What

Fixed the commented out tests so they work using the recent changes to the step code.  One of the tests has highlighted an error in the production once it was running so that test has been commented out until the bug is fixed.

<!-- Describe what you have changed and why -->

## How to review

1. Code Review
2. Run tests against an environment such as staging.
3. 
<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
