### PR TITLE
BAU: Revert Selenium to 4.11.0

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -14,7 +14,7 @@ def dependencyVersions = [
     junit_version: '5.11.3',
     cucumber_version: '7.20.1',
     axe_version: '3.0',
-    selenium_java_version: '4.26.0',
+    selenium_java_version: '4.11.0',
     aws_sdk_v2_version: "2.29.6",
     json_version: '20240303',
     rest_assured: '5.5.0'
@@ -25,7 +25,7 @@ dependencies {
 
     testImplementation(platform("software.amazon.awssdk:bom:${dependencyVersions.aws_sdk_v2_version}"))
     testImplementation(platform("io.cucumber:cucumber-bom:${dependencyVersions.cucumber_version}"))
-    testImplementation(platform("org.seleniumhq.selenium:selenium-dependencies-bom:${dependencyVersions.selenium_java_version}"))
+    testImplementation("org.seleniumhq.selenium:selenium-java:${dependencyVersions.selenium_java_version}")
 
     testImplementation("software.amazon.awssdk:sso")
     testImplementation("software.amazon.awssdk:ssooidc")


### PR DESCRIPTION
## What

Revert Selenium to 4.11.0

## How to review

Later versions are suspected of causing acceptance test flakes.  4.5.0 appeared to be better, but this version does not contain Selenium Manager (https://www.selenium.dev/documentation/selenium_manager/) whose features we would like to use, so rolling back to the earliest version with Selenium Manager for Chrome (4.11.0)

The change has been tested by a local acceptance test run against build.

1. Code Review
1. Local acceptance test run against the build environment

## Related PRs

There was a noticeable drop in success rates after this: https://github.com/govuk-one-login/authentication-acceptance-tests/commit/9a77a4bba16b8bb130c8cd42fb940082a2d6ee42#diff-754c42c3563eb7a6a9f94cc57e69fc84a5015de90c4c50c16e64341495607145L21

https://github.com/govuk-one-login/authentication-acceptance-tests/pull/437


