### PR TITLE
BAU: Ignore selenium-java versions > 4.11.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,10 @@ updates:
     schedule:
       interval: daily
       time: "03:00"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 100
+    ignore:
+      - dependency-name: "org.seleniumhq.selenium:selenium-java"
+        versions: [ "> 4.11.0" ]
     groups:
       gradle-all-dependencies:
         patterns:


### PR DESCRIPTION

## What

Ignore selenium-java versions > 4.11.0

Later versions suspected of causing acceptance test flakes

## How to review

1. Code Review

## Related PRs

See #481 