### PR TITLE
Revert "BAU: Bump the gradle-all-dependencies group across 1 directory with 2 updates"

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -14,8 +14,8 @@ def dependencyVersions = [
     junit_version: '5.11.4',
     cucumber_version: '7.20.1',
     axe_version: '3.0',
-    selenium_java_version: '4.28.0',
-    aws_sdk_v2_version: "2.30.2",
+    selenium_java_version: '4.27.0',
+    aws_sdk_v2_version: "2.29.52",
     json_version: '20250107',
     rest_assured: '5.5.0'
 ]


### PR DESCRIPTION
Reverts govuk-one-login/authentication-acceptance-tests#545

Starting to see flakey tests, so revert this bump which includes selenium (as we've seen these kind of bumps cause issues in the past)