### PR TITLE
AUT-4051

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/Mfa_reset.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/Mfa_reset.feature
@@ -339,3 +339,19 @@ Feature: The MFA reset process.
     Examples:
       | Mfa Type | Page                                                            |
       | App      | Enter the 6 digit security code shown in your authenticator app |
+
+  @AUT-4051 @under-development
+  Scenario Outline: User is signing in via the one login v2 app
+    Given a user with "<Mfa Type>" MFA exists
+    When the user comes from the stub relying party with option channel-strategic-app and is taken to the "Sign in to GOV.UK One Login" page
+    And the user selects sign in
+    And the user enters their email address
+    And the user enters their password
+    And the user selects "<Link Text>" link
+    And the user selects "check if you can change how you get security codes" link
+    Then the user is taken to the "<Page>" page
+    Then the URL is present with suffix "open-one-login-in-web-browser"
+    Examples:
+      | Mfa Type | Link Text                                     | Page                                               |
+      | App      | I do not have access to the authenticator app | Open GOV.UK One Login in a web browser to continue |
+      | SMS      | Problems with the code?                       | Open GOV.UK One Login in a web browser to continue |


### PR DESCRIPTION
Approval Request for Acceptance Test Merge

This PR introduces an acceptance test to validate the new MFA reset guidance screen and routing logic. The test ensures that when a user initiates the MFA reset journey via an app (V2 One Login app or HMRC app), they are correctly presented with the guidance screen instructing them to switch to a web browser.

The test covers:

Verification that the guidance screen appears when channel = 'strategic_app'
Validation of the correct content displayed in both English and Welsh
Ensuring the guidance is triggered upon clicking the "Check if you can change how you get security codes" link on the OTP entry screens
This test helps confirm the expected behaviour before release. Please review and approve for merging into the main repository.
