### PR TITLE
@underdevelopment tag has been removed

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/010_existing_user_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/010_existing_user_journey.feature
@@ -50,7 +50,7 @@ Feature: Login Journey
     Then the user is taken to the "Enter your password" page
     When the user enters their password
     Then the user is returned to the service
-    When the user comes from the stub relying party with options: [2fa-on,authenticated-2,authenticated-level] and is taken to the "Enter a security code to continue" page
+    When the user comes from the stub relying party with options: [level,authenticated-2,authenticated-level] and is taken to the "Enter a security code to continue" page
     Then the user is taken to the "Enter a security code to continue" page
     When the user enters the six digit security code from their phone
     Then the user is returned to the service

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/Mfa_reset.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/Mfa_reset.feature
@@ -6,7 +6,7 @@ Feature: The MFA reset process.
   whether the user is classified as authentication-only or identity-verified.
 
 # ************************* SMS Section *************************
-  @AUT-3825 @under-development
+  @AUT-3825
   Scenario: SMS User selects SMS OTP for MFA reset after successful identity verification
     Given a user with SMS MFA exists
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -26,7 +26,7 @@ Feature: The MFA reset process.
     Then the user is returned to the service
 
 
-  @AUT-3825 @under-development
+  @AUT-3825
   Scenario: AUTH app User selects SMS OTP for MFA reset after successful identity verification
     Given a user with App MFA exists
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -46,7 +46,7 @@ Feature: The MFA reset process.
     Then the user is returned to the service
 
 # ************************* AUTH APP Section *************************
-  @AUT-3825 @under-development
+  @AUT-3825
   Scenario: Auth app User selects Authenticate app for MFA reset after successful identity verification
     Given a user with App MFA exists
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -67,7 +67,7 @@ Feature: The MFA reset process.
     Then the user is returned to the service
 
 
-  @AUT-3825 @under-development
+  @AUT-3825
   Scenario: SMS User selects Authenticate app for MFA reset after successful identity verification
     Given a user with SMS MFA exists
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -88,7 +88,7 @@ Feature: The MFA reset process.
     Then the user is returned to the service
 
 # ************************* Negative tests when for unsuccessful IPV responses **********************
-  @AUT-3930 @AUT-3920 @under-development
+  @AUT-3930 @AUT-3920
   Scenario Outline: Mfa User choose to reset their MFA but are unsuccessful in identity verification test
     Given a user with "<Mfa Type>" MFA exists
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -116,7 +116,7 @@ Feature: The MFA reset process.
       | App      | I do not have access to the authenticator app | Identity did not match | Enter the 6 digit security code shown in your authenticator app |
 
 
-  @AUT-3931 @under-development
+  @AUT-3931
   Scenario Outline: Mfa User Error scenario - get help to delete your account
     Given a user with "<Mfa Type>" MFA exists
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -144,7 +144,7 @@ Feature: The MFA reset process.
       | App      | I do not have access to the authenticator app | Identity check incomplete |
 
 # ************************* Additional tests for IPV MFA journey **********************
-  @AUT-3997 @under-development
+  @AUT-3997
   Scenario Outline: Mfa User choose to use Back button when choosing the ‘Try entering a security code again’ option
     Given a user with "<Mfa Type>" MFA exists
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -176,7 +176,7 @@ Feature: The MFA reset process.
       | App      | I do not have access to the authenticator app | Identity did not match | Enter the 6 digit security code shown in your authenticator app |
 
 
-  @AUT-3997 @under-development
+  @AUT-3997
   Scenario Outline: Mfa User choose to use Back-button from contact screen
     Given a user with "<Mfa Type>" MFA exists
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -207,7 +207,7 @@ Feature: The MFA reset process.
       | App      | I do not have access to the authenticator app | Identity check incomplete | Enter the 6 digit security code shown in your authenticator app |
 
 
-  @AUT-3993 @under-development
+  @AUT-3993
   Scenario Outline: MFA reset is switched on and APP user can reset their MFA method after resetting their password
     Given a user with "<Mfa Type>" MFA exists
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -247,7 +247,7 @@ Feature: The MFA reset process.
       | App      | I do not have access to the authenticator app | Success      | Enter the 6 digit security code shown in your authenticator app |
 
 
-  @AUT-3993 @under-development
+  @AUT-3993
   Scenario Outline: MFA reset is switched on and SMS user can reset their MFA method after resetting their password
     Given a user with "<Mfa Type>" MFA exists
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -348,7 +348,7 @@ Feature: The MFA reset process.
       | Mfa Type | Page                                                            |
       | App      | Enter the 6 digit security code shown in your authenticator app |
 
-  @AUT-4051 @under-development
+  @AUT-4051
   Scenario Outline: User is signing in via the one login v2 app
     Given a user with "<Mfa Type>" MFA exists
     When the user comes from the stub relying party with option channel-strategic-app and is taken to the "Sign in to GOV.UK One Login" page

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/account_interventions.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/account_interventions.feature
@@ -130,7 +130,7 @@ Feature: Account interventions
     When the user enters the six digit security code from their email
     Then the user is taken to the "Sorry, there is a problem" page
 
-  @under-development @AUT-3921
+  @AUT-3921
   Scenario: Auth app user cannot change the way they get security codes when they have a temporarily suspended account (Dev only Test)
     Given a user with App MFA exists
     And the user has a temporarily suspended intervention
@@ -144,12 +144,10 @@ Feature: Account interventions
     When the user selects "I do not have access to the authenticator app" link
     When the user selects "check if you can change how you get security codes" link
     Then the user is taken to the IPV stub page
-    When "<IPV Response>" radio option selected
+    When "Identity check failed " radio option selected
     And the user clicks the continue button
     Then the user is taken to the "You cannot change how you get security codes" page
-    Examples:
-      | Mfa Type | Link Text                                     | IPV Response              |
-      | App      | I do not have access to the authenticator app | Identity check failed     |
+
 
   @locked @build-sp @dev
   Scenario: Sms user cannot log in when they have a permanently locked account
@@ -260,7 +258,7 @@ Feature: Account interventions
     When the user enters the six digit security code from their email
     Then the user is taken to the "Your GOV.UK One Login has been permanently locked" page
 
-  @under-development @AUT-3921
+  @AUT-3921
   Scenario: Sms user cannot change the way they get security codes when they have a permanently locked account (Dev only Test)
     Given a user with SMS MFA exists
     And the user has a permanently locked intervention
@@ -275,12 +273,9 @@ Feature: Account interventions
     Then User see updated text If you cannot access the phone number for your GOV.UK One Login
     When the user selects "check if you can change how you get security codes" link
     Then the user is taken to the IPV stub page
-    When "<IPV Response>" radio option selected
+    When "Identity check failed " radio option selected
     And the user clicks the continue button
     Then the user is taken to the "You cannot change how you get security codes" page
-    Examples:
-      | Mfa Type | Link Text                                     | IPV Response              |
-      | SMS      | I do not have access to the authenticator app | Identity check failed     |
 
   @locked @build-sp
   Scenario: Auth app user cannot change the way they get security codes when they have a permanently locked account
@@ -299,7 +294,7 @@ Feature: Account interventions
     When the user enters the six digit security code from their email
     Then the user is taken to the "Your GOV.UK One Login has been permanently locked" page
 
-  @under-development @AUT-3921
+ @AUT-3921
   Scenario: Auth app user cannot change the way they get security codes when they have a permanently locked account (Dev Only Test)
     Given a user with App MFA exists
     And the user has a permanently locked intervention
@@ -314,12 +309,9 @@ Feature: Account interventions
     Then User see updated text If you no longer have access to your authenticator app, check if you can change how you get security codes
     When the user selects "check if you can change how you get security codes" link
     Then the user is taken to the IPV stub page
-    When "<IPV Response>" radio option selected
+    When "Identity check failed" radio option selected
     And the user clicks the continue button
     Then the user is taken to the "You cannot change how you get security codes" page
-    Examples:
-      | Mfa Type | Link Text                                     | IPV Response              |
-      | App      | I do not have access to the authenticator app | Identity check failed     |
 
 #  @reset_password # commented out due to an unidentified data issue that causes failure in th pipeline. Runs fine locally.
 #  Scenario: Sms user forced to reset their password when a password reset intervention has been placed on their account

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/account_recovery.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/account_recovery.feature
@@ -34,7 +34,7 @@ Feature: Account recovery
     When the user enters the security code from the auth app
     Then the user is returned to the service
 
-  @under-development @AUT-3921
+  @AUT-3921
   Scenario: An sms user can change how they get security codes and log in with new method (Dev Test Only)
     Given a user with SMS MFA exists
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -100,7 +100,7 @@ Feature: Account recovery
     When the user enters the six digit security code from their phone
     Then the user is returned to the service
 
-  @under-development @AUT-3921
+  @AUT-3921
   Scenario: An auth app user can change how they get security codes and log in with new method (Dev Test Only)
     Given a user with App MFA exists
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page


### PR DESCRIPTION
This PR removes the @underdevelopment tag and which previously prevented these scripts from running the acceptance tests in the build due to MFA being turned off. Now MFA will be enabled to allow acceptance tests to run in the build environment, these tests will run to ensure all testing is completed before we can sign-off for go live.

