### PR TITLE
AUT-4047: Separate old and new mfa tests

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/Mfa_reset.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/Mfa_reset.feature
@@ -6,7 +6,7 @@ Feature: The MFA reset process.
   whether the user is classified as authentication-only or identity-verified.
 
 # ************************* SMS Section *************************
-  @AUT-3825 @under-development
+  @AUT-3825 @new-mfa-reset-with-ipv @under-development
   Scenario: SMS User selects SMS OTP for MFA reset after successful identity verification
     Given a user with SMS MFA exists
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -26,7 +26,7 @@ Feature: The MFA reset process.
     Then the user is returned to the service
 
 
-  @AUT-3825 @under-development
+  @AUT-3825 @new-mfa-reset-with-ipv @under-development
   Scenario: AUTH app User selects SMS OTP for MFA reset after successful identity verification
     Given a user with App MFA exists
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -46,7 +46,7 @@ Feature: The MFA reset process.
     Then the user is returned to the service
 
 # ************************* AUTH APP Section *************************
-  @AUT-3825 @under-development
+  @AUT-3825 @new-mfa-reset-with-ipv @under-development
   Scenario: Auth app User selects Authenticate app for MFA reset after successful identity verification
     Given a user with App MFA exists
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -67,7 +67,7 @@ Feature: The MFA reset process.
     Then the user is returned to the service
 
 
-  @AUT-3825 @under-development
+  @AUT-3825 @new-mfa-reset-with-ipv @under-development
   Scenario: SMS User selects Authenticate app for MFA reset after successful identity verification
     Given a user with SMS MFA exists
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -88,7 +88,7 @@ Feature: The MFA reset process.
     Then the user is returned to the service
 
 # ************************* Negative tests when for unsuccessful IPV responses **********************
-  @AUT-3930 @AUT-3920 @under-development
+  @AUT-3930 @AUT-3920 @new-mfa-reset-with-ipv @under-development
   Scenario Outline: Mfa User choose to reset their MFA but are unsuccessful in identity verification test
     Given a user with "<Mfa Type>" MFA exists
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -116,7 +116,7 @@ Feature: The MFA reset process.
       | App      | I do not have access to the authenticator app | Identity did not match | Enter the 6 digit security code shown in your authenticator app |
 
 
-  @AUT-3931 @under-development
+  @AUT-3931 @new-mfa-reset-with-ipv @under-development
   Scenario Outline: Mfa User Error scenario - get help to delete your account
     Given a user with "<Mfa Type>" MFA exists
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -144,7 +144,7 @@ Feature: The MFA reset process.
       | App      | I do not have access to the authenticator app | Identity check incomplete |
 
 # ************************* Additional tests for IPV MFA journey **********************
-  @AUT-3997 @under-development
+  @AUT-3997 @new-mfa-reset-with-ipv @under-development
   Scenario Outline: Mfa User choose to use Back button when choosing the ‘Try entering a security code again’ option
     Given a user with "<Mfa Type>" MFA exists
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -176,7 +176,7 @@ Feature: The MFA reset process.
       | App      | I do not have access to the authenticator app | Identity did not match | Enter the 6 digit security code shown in your authenticator app |
 
 
-  @AUT-3997 @under-development
+  @AUT-3997 @new-mfa-reset-with-ipv @under-development
   Scenario Outline: Mfa User choose to use Back-button from contact screen
     Given a user with "<Mfa Type>" MFA exists
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -207,7 +207,7 @@ Feature: The MFA reset process.
       | App      | I do not have access to the authenticator app | Identity check incomplete | Enter the 6 digit security code shown in your authenticator app |
 
 
-  @AUT-3993 @under-development
+  @AUT-3993 @new-mfa-reset-with-ipv @under-development
   Scenario Outline: MFA reset is switched on and APP user can reset their MFA method after resetting their password
     Given a user with "<Mfa Type>" MFA exists
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -247,7 +247,7 @@ Feature: The MFA reset process.
       | App      | I do not have access to the authenticator app | Success      | Enter the 6 digit security code shown in your authenticator app |
 
 
-  @AUT-3993 @under-development
+  @AUT-3993 @new-mfa-reset-with-ipv @under-development
   Scenario Outline: MFA reset is switched on and SMS user can reset their MFA method after resetting their password
     Given a user with "<Mfa Type>" MFA exists
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -348,7 +348,7 @@ Feature: The MFA reset process.
       | Mfa Type | Page                                                            |
       | App      | Enter the 6 digit security code shown in your authenticator app |
 
-  @AUT-4051 @under-development
+  @AUT-4051 @new-mfa-reset-with-ipv @under-development
   Scenario Outline: User is signing in via the one login v2 app
     Given a user with "<Mfa Type>" MFA exists
     When the user comes from the stub relying party with option channel-strategic-app and is taken to the "Sign in to GOV.UK One Login" page


### PR DESCRIPTION
## What

While we have two pipelines we will need two run the acceptance tests against two build environments.  One of these will have the new MFA reset with IPV feature switched on, the new secure pipeline, the other will have it switched off, the old pipeline.

When we enable the new MFA reset we will use tags
as follows:

@new-mfa-reset-with-ipv in old build to exclude mfa tests 
@old-mfa-without-ipv in new build to exclude old mfa tests

<!-- Describe what you have changed and why -->

## How to review
1. Code Review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
