### PR TITLE
BAU: Build SP migration - suspend old mfa reset tests

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/account_interventions.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/account_interventions.feature
@@ -447,7 +447,7 @@ Feature: Account interventions
     When the user enters valid new password and correctly retypes it
     Then the user is returned to the service
 
-  @under-development @AUT-3921
+  @under-development @AUT-3921 @old-mfa-without-ipv
   Scenario: Auth app user cannot change the way they get security codes when they have a password reset intervention on their account (Dev Only Test)
     Given a user with App MFA exists
     And the user has a password reset intervention


### PR DESCRIPTION


## What

Build SP migration - suspend old mfa reset tests

Tests suspended as they need to be adapted to the new mfa reset journey. They are currently failing in the backend pipeline where mfa reset was not switched on before migration to SP

## How to review

1. Code Review

## Related PRs

#597 
#598 
