### PR TITLE
Bau/tests build sp migration 4

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/account_interventions.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/account_interventions.feature
@@ -424,7 +424,7 @@ Feature: Account interventions
     When the user enters valid new password and correctly retypes it
     Then the user is returned to the service
 
-  @reset_password @build-sp
+  @reset_password @build-sp @old-mfa-without-ipv
   Scenario: Auth app user cannot change the way they get security codes when they have a password reset intervention on their account
     Given a user with App MFA exists
     And the user has a password reset intervention


### PR DESCRIPTION
## What

Build SP migration - suspend old mfa reset tests

Tests suspended as they need to be adapted to the new mfa reset journey. They are currently failing in the backend pipeline where mfa reset was not switched on before migration to SP

## How to review

1. Code Review

## Related PRs

https://github.com/govuk-one-login/authentication-acceptance-tests/pull/597
https://github.com/govuk-one-login/authentication-acceptance-tests/pull/598
#599 
