### PR TITLE
BAU: Revert tmp changes that disable cache

### DIFF
--- a/.github/workflows/build-and-push-tests-SP.yaml
+++ b/.github/workflows/build-and-push-tests-SP.yaml
@@ -41,6 +41,6 @@ jobs:
           ECR_REPOSITORY: ${{ secrets.ACCEPTANCE_ECR_REPO_NEW_BUILD }}
           IMAGE_TAG: latest
         run: |
-          docker build --no-cache -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f Dockerfile.sp .
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f Dockerfile.sp .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           cosign sign --key awskms:///${CONTAINER_SIGN_KMS_KEY} $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/build-and-push-tests.yaml
+++ b/.github/workflows/build-and-push-tests.yaml
@@ -38,5 +38,5 @@ jobs:
           ECR_REPOSITORY: ${{ secrets.ACCEPTANCE_ECR_REPO }}
           IMAGE_TAG: latest
         run: |
-          docker build --no-cache -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG


### PR DESCRIPTION
## What

As part of an investigation into why acceptance test images are not being build with latest changes we tried `--no-cache`. This is no longer required.

## How to review

1. Code Review