### PR TITLE
BAU: run #cores+1 tests at once

### DIFF
--- a/docker/run-tests-sp.sh
+++ b/docker/run-tests-sp.sh
@@ -36,6 +36,11 @@ export AWS_SECRET_ACCESS_KEY="$(echo "$output" | jq -r '.Credentials.SecretAcces
 # shellcheck disable=SC2155
 export AWS_SESSION_TOKEN="$(echo "$output" | jq -r '.Credentials.SessionToken')"
 
+PROCESSOR_CORES=$(nproc --all 2> /dev/null || echo 1)
+
+# run one more browser than we have cores
+export PARALLEL_BROWSERS=$((PROCESSOR_CORES + 1))
+
 /test/run-acceptance-tests.sh -s "${ENVIRONMENT}"
 return_code=$?
 


### PR DESCRIPTION
## What

Run #cores+1 tests in parallel. Ideally it'd be 1:1, but as there are waits in some of the tests, a bit of context switching is acceptable.

## How to review

- Code review
- Check reasoning is sound

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
