### PR TITLE
BAU: Exclude `selenium` from Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,11 @@ updates:
       - dependency-name: "org.seleniumhq.selenium:selenium-java"
         versions: [ "> 4.11.0" ]
     groups:
-      gradle-all-dependencies:
+      gradle-most-dependencies:
         patterns:
           - "*"
+        exclude-patterns:
+          - "*selenium*"
     target-branch: main
     commit-message:
       prefix: BAU


### PR DESCRIPTION
## What

We have a Dependabot group to bring all gradle dependency updates into one PR, which works for most of the time.

We've found it's too easy to accidentally merge Selenium bumps, which should be handled separately as it requires closer testing and a Dockerfile bump too.

## How to review

1. Code Review