### PR TITLE
BAU: Allow rundocker.sh to target dev-sp

### DIFF
--- a/docker/run-tests-sp.sh
+++ b/docker/run-tests-sp.sh
@@ -11,6 +11,9 @@ fi
 ENVIRONMENT=${TEST_ENVIRONMENT:-local}
 
 case $ENVIRONMENT in
+  dev)
+    CROSSACCOUNT_ROLEARN="arn:aws:iam::653994557586:role/CrossAccountRole-new-dev"
+    ;;
   build)
     CROSSACCOUNT_ROLEARN="arn:aws:iam::761723964695:role/CrossAccountRole-new-build"
     ;;

--- a/rundocker.sh
+++ b/rundocker.sh
@@ -30,6 +30,11 @@ case "${ENVIRONMENT}" in
   dev)
     AWS_PROFILE=di-auth-development-admin
     ;;
+  dev-sp)
+    SP=true
+    AWS_PROFILE=di-authentication-development-admin
+    ENVIRONMENT=dev
+    ;;
   *)
     echo "Unconfigured environment: $ENVIRONMENT"
     exit 1


### PR DESCRIPTION
## What

Our frontend in the new AWS account for secure pipeline requires a cross account role so we can test the new frontend, but against the old backend.

This configures the scripts to do so.

Can be executed with `./rundocker.sh dev-sp`.

SSM parameters have been set up in the new account so it loads the correct acceptance test configuration.

## How to review

1. Code Review