### PR TITLE
AUT-4202: Workflow to deploy branch images to new SP Dev account

### DIFF
--- a/.github/workflows/build-and-push-tests-SP-dev.yaml
+++ b/.github/workflows/build-and-push-tests-SP-dev.yaml
@@ -1,0 +1,64 @@
+name: Build and Push Tests DEV Secure Pipeline
+
+env:
+  AWS_REGION: eu-west-2
+  SELENIUM_BASE: selenium/standalone-chromium:132.0
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: "build-and-push-tests-sp-dev"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up AWS credentials
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: ${{ secrets.GHA_DEPLOYER_ROLE_NEW_DEV }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
+        with:
+          cosign-release: "v1.9.0"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Build and push
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        id: build-and-push
+        with:
+          context: .
+          push: true
+          target: secure-pipelines
+          build-args: |
+            SELENIUM_BASE=${{ env.SELENIUM_BASE }}
+          tags: "${{ steps.login-ecr.outputs.registry }}/${{ secrets.ACCEPTANCE_ECR_REPO_NEW_DEV }}:latest"
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Sign image with Cosign
+        env:
+          TAGS: "${{ steps.login-ecr.outputs.registry }}/${{ secrets.ACCEPTANCE_ECR_REPO_NEW_DEV }}:latest"
+          CONTAINER_SIGN_KMS_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        run: |
+          cosign sign --yes \
+            --key awskms:///${CONTAINER_SIGN_KMS_KEY} \
+            "${{ steps.login-ecr.outputs.registry }}/${{ secrets.ACCEPTANCE_ECR_REPO_NEW_DEV }}:latest@${DIGEST}"


### PR DESCRIPTION
## What

Workflow to deploy branch images to new SP Dev account
Deploys to `di-authentication-development` account `acceptance-tests-image-repository` 
IAM Role used: frontend-pipeline GitHubActionsRoleArn from the same account
 
## How to review

Same as [build-and-push-tests-SP.yaml](https://github.com/govuk-one-login/authentication-acceptance-tests/blob/main/.github/workflows/build-and-push-tests-SP.yaml), except the role to assume and repository to push are different, and specific to dev account