### PR TITLE
AUT-4202: Use new dev container signer key

### DIFF
--- a/.github/workflows/build-and-push-tests-SP-dev.yaml
+++ b/.github/workflows/build-and-push-tests-SP-dev.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Sign image with Cosign
         env:
           TAGS: "${{ steps.login-ecr.outputs.registry }}/${{ secrets.ACCEPTANCE_ECR_REPO_NEW_DEV }}:latest"
-          CONTAINER_SIGN_KMS_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
+          CONTAINER_SIGN_KMS_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY_NEW_DEV }}
           DIGEST: ${{ steps.build-and-push.outputs.digest }}
         run: |
           cosign sign --yes \


### PR DESCRIPTION
## What

Use dev container signer key for [build-and-push-tests-SP-dev.yaml](https://github.com/govuk-one-login/authentication-acceptance-tests/blob/main/.github/workflows/build-and-push-tests-SP-dev.yaml)

