### PR TITLE
AUT-1416: Fix migrated user creation

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/StubStartPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/StubStartPage.java
@@ -15,6 +15,7 @@ public abstract class StubStartPage extends BasePage {
     protected static final String RP_URL = TEST_CONFIG_SERVICE.get("RP_URL");
 
     public void goToRpStub() {
+        System.out.println("Go to RP stub page: " + RP_URL);
         Driver.get().get(RP_URL);
         waitForStubToLoad();
     }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/services/UserLifecycleService.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/services/UserLifecycleService.java
@@ -220,7 +220,7 @@ public class UserLifecycleService {
                             MFAMethodType.SMS.name(),
                             true,
                             true,
-                            "07700900111",
+                            "+447700900000",
                             "date",
                             PriorityIdentifier.DEFAULT,
                             "1");

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/api/account-management/migrated-user-scenarios/mfa-methods-default-sms-user.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/api/account-management/migrated-user-scenarios/mfa-methods-default-sms-user.feature
@@ -38,3 +38,24 @@ Feature: SMS MFA User manages their MFA methods via the Method Management API
     Given the User does not have a Backup MFA method
     And the User requests to add a backup MFA Auth App
     When the User cannot update their Default MFA to an Auth App
+
+  Scenario: Use backup SMS to log in.
+    And the User does not have a Backup MFA method
+    When the User adds "07700900111" as their SMS Backup MFA
+    Then the system sends an OTP to "07700900111"
+    When the User provides the correct otp
+    Then "07700900111" is added as a verified Backup MFA Method
+
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    And the user clicks logout
+
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
+    When the user enters their email address
+    Then the user is taken to the "Enter your password" page
+    When the user enters their password
+    Then the user is taken to the "Check your phone" page
+    And the user selects "Problems with the code?" link
+    And the user selects "try another way to get a security code" link
+    Then the user is taken to the "How do you want to get a security code?" page


### PR DESCRIPTION

## What

There is code in the authentication-api that ensures that only normalised phone numbers are stored.  That means all phone numbers will have the international dialing code prefixed.  Therefore any test data created by updating DynamoDB directly also needs to be in this format.

<!-- Describe what you have changed and why -->

## How to review
1. Code Review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
