### PR TITLE
AUT-4309: Fix default method change to Auth App test

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/MFAMethodsAPIStepdefs.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/MFAMethodsAPIStepdefs.java
@@ -81,7 +81,7 @@ public class MFAMethodsAPIStepdefs {
             if (actualStatusCode != 200) {
                 LOG.info("Error response: {}", payloadJson.get("body"));
             }
-            assertEquals(500, actualStatusCode);
+            assertEquals(400, actualStatusCode);
         } catch (JsonProcessingException e) {
             fail("Error parsing JSON response: " + e.getMessage());
         }


### PR DESCRIPTION
## What

The test scenario of a User with a backup auth app not being allowed to change the default to an auth app was not checking the correct response status code.

<!-- Describe what you have changed and why -->

## How to review
1. Code Review
<!-- Describe the steps required to review this PR.
For example:


1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
