### PR TITLE
AUT-4345: Option to use API_RP_URL if the test stage is on backend pipeline

### DIFF
--- a/docker/run-tests-sp.sh
+++ b/docker/run-tests-sp.sh
@@ -29,6 +29,17 @@ esac
 # shellcheck source=../scripts/fetch_envars.sh
 /test/scripts/fetch_envars.sh "${ENVIRONMENT}" | tee /test/.env
 
+if [ "${SAM_STACK_NAME:-}" == "authentication-api" ]; then
+  if grep -qE '^API_RP_URL=' /test/.env; then
+    API_RP_URL=$(grep ^API_RP_URL= /test/.env | cut -d= -f2-)
+
+    if grep -qE '^RP_URL=' /test/.env; then
+      sed -i '/^RP_URL=.*/d' /test/.env
+    fi
+    echo -e "RP_URL=${API_RP_URL}" | tee --append /test/.env
+  fi
+fi
+
 echo "Assuming cross-account role"
 output=$(aws sts assume-role --role-arn "$CROSSACCOUNT_ROLEARN" --role-session-name "dynamo-db-access" --output json)
 


### PR DESCRIPTION
## What

Option to use API_RP_URL if the test stage is on backend pipeline.
Introduced a new optional SSM parameter `API_RP_URL`, if defined and `SAM_STACK_NAME="authentication-api"`, then the URL replaces current `RP_URL`.

Issue: [AUT-4345]

## How to review

See JIRA ticket [AUT-4345] for detailed local testing instructions

[AUT-4345]: https://govukverify.atlassian.net/browse/AUT-4345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AUT-4345]: https://govukverify.atlassian.net/browse/AUT-4345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ