### PR TITLE
ATO-1621: Remove authenticated-level from radio option selection

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/LegacyStubStartPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/LegacyStubStartPage.java
@@ -8,9 +8,7 @@ import java.util.List;
 
 public class LegacyStubStartPage extends StubStartPage {
     List<String> ignoredOptions =
-            List.of(
-                    "authenticated-2",
-                    "authenticated-level"); // Options only used by orchestration stub
+            List.of("authenticated-2"); // Options only used by orchestration stub
 
     protected LegacyStubStartPage() {
         // protected constructor to prevent direct instantiation

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/005_auth_app_2fa_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/005_auth_app_2fa_journey.feature
@@ -55,4 +55,4 @@ Feature: Authentication App Journeys
     When the user enters their password
     Then the user is returned to the service
 
-    Then the user comes from the stub relying party with options: [2fa-on,authenticated-2,authenticated-level] and is taken to the "Enter a security code to continue" page
+    Then the user comes from the stub relying party with options: [2fa-on,authenticated-2] and is taken to the "Enter a security code to continue" page

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/010_existing_user_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/010_existing_user_journey.feature
@@ -50,7 +50,7 @@ Feature: Login Journey
     Then the user is taken to the "Enter your password" page
     When the user enters their password
     Then the user is returned to the service
-    When the user comes from the stub relying party with options: [2fa-on,authenticated-2,authenticated-level] and is taken to the "Enter a security code to continue" page
+    When the user comes from the stub relying party with options: [2fa-on,authenticated-2] and is taken to the "Enter a security code to continue" page
     Then the user is taken to the "Enter a security code to continue" page
     When the user enters the six digit security code from their phone
     Then the user is returned to the service


### PR DESCRIPTION
## What

`authentication-level` has been removed as an option in the Orch stub, so we shouldn't be trying to press it any more.

## How to review

1. Code Review