### PR TITLE
BAU: Fix test reports in the secure pipelines

### DIFF
--- a/docker/run-tests-sp.sh
+++ b/docker/run-tests-sp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # NOTE: this script only runs in codebuild in new secure pipeline
 # This file is put in place during docker build, so paths to other scripts are relative to the docker context
-set -euo pipefail
+set -uo pipefail
 
 if [[ -z ${CODEBUILD_BUILD_ID:-} ]]; then
   echo 'This should only be run in codebuild'

--- a/rundocker.sh
+++ b/rundocker.sh
@@ -43,6 +43,8 @@ esac
 
 export AWS_PROFILE
 source ./scripts/check_aws_creds.sh
+results_dir=/tmp/results/$(date +%Y-%m-%d-%H-%M-%S)
+mkdir -p "${results_dir}"
 
 if [ "${SP}" = "true" ]; then
   docker build . -t acceptance:latest --target secure-pipelines \
@@ -50,6 +52,7 @@ if [ "${SP}" = "true" ]; then
   docker run -p 4442-4444:4442-4444 --privileged \
     -e CODEBUILD_BUILD_ID=1 -e AWS_REGION="${AWS_REGION:-eu-west-2}" \
     -e TEST_ENVIRONMENT="${ENVIRONMENT}" -e PARALLEL_BROWSERS=1 \
+    -v "${results_dir}":/test/results \
     --env-file <(aws configure export-credentials --format env-no-export) \
     -it --rm --entrypoint /bin/bash --shm-size="2g" acceptance:latest /run-tests.sh
 else
@@ -57,6 +60,7 @@ else
     --build-arg "SELENIUM_BASE=selenium/standalone-${BROWSER}:132.0"
   docker run -p 4442-4444:4442-4444 --privileged \
     -e PARALLEL_BROWSERS=1 \
+    -v "${results_dir}":/test/acceptance-tests/target/cucumber-report \
     --env-file <(aws configure export-credentials --format env-no-export) \
     -it --rm --entrypoint /bin/bash --shm-size="2g" acceptance:latest /test/run-acceptance-tests.sh -s "${ENVIRONMENT}"
 fi


### PR DESCRIPTION
## What

Removing set -e option allows run-tests-sp.sh to process the reports before exiting with non-zero code where applicable Additionally, if running tests locally using rundocker.sh, we can view test reports in /tmp/results/<datetime> directory

## How to review

Run commands i.e. `./rundocker.sh build`