### PR TITLE
ATO-1644: Tweak multitab reauth tests for no shared session

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/Reauthentication.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/Reauthentication.feature
@@ -142,6 +142,8 @@ Feature: Reauthentication of user
     And the user logs out
     And the user switches back to the second tab
     And the user enters their email address for reauth
+    And the user enters the correct password
+    And the user enters the six digit security code from their phone
     Then the user is taken to the "There’s a problem with this service" page
 
 
@@ -155,7 +157,8 @@ Feature: Reauthentication of user
     And the user switches back to the first tab
     And the user logs out
     And the user switches back to the second tab
-    When the user enters their password
+    And the user enters the correct password
+    And the user enters the six digit security code from their phone
     Then the user is taken to the "There’s a problem with this service" page
 
 


### PR DESCRIPTION
## What:
- Updates the multitab reauth tests to reflect the fact that there will be no shared session between Orchestration and Authentication. 

## How to review: 
- Code review - the commit message is quite detailed
- Deployed to https://github.com/govuk-one-login/authentication-api/pull/6591 to sandpit and ran these specific test cases with a custom cucumber tag and they passed

## Related PRs: 
- Requires https://github.com/govuk-one-login/authentication-api/pull/6591 to be merged in 
