### PR TITLE
AUT-4183 User selects back-up MFA for password reset

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CrossPageFlows.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CrossPageFlows.java
@@ -307,7 +307,7 @@ public class CrossPageFlows extends BasePage {
     }
 
     public void requestAuthSecurityCodeResendNumberOfTimes(
-        Integer numberOfTimes, Boolean isReauth) {
+                Integer numberOfTimes, Boolean isReauth) {
             for (int i = 0; i < numberOfTimes; i++) {
                 checkYourPhonePage.clickProblemsWithTheCodeLink();
                 checkYourPhonePage.clickSendTheCodeAgainLink();

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CrossPageFlows.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CrossPageFlows.java
@@ -305,4 +305,23 @@ public class CrossPageFlows extends BasePage {
                 throw new RuntimeException("Invalid method type: " + userType);
         }
     }
+
+    public void requestAuthSecurityCodeResendNumberOfTimes(
+        Integer numberOfTimes, Boolean isReauth) {
+            for (int i = 0; i < numberOfTimes; i++) {
+                checkYourPhonePage.clickProblemsWithTheCodeLink();
+                checkYourPhonePage.clickSendTheCodeAgainLink();
+                waitForPageLoad("Get security code");
+                if (isReauth) {
+                    waitForThisText("you will be signed out");
+                }
+                getSecurityCodePage.pressGetSecurityCodeButton();
+                System.out.println(
+                        "Code request count: "
+                                + (i + 1)
+                                + " ("
+                                + (i + 2)
+                                + " including code sent on initial entry to the Check Your Auth page)");
+            }
+    }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CrossPageFlows.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CrossPageFlows.java
@@ -307,21 +307,21 @@ public class CrossPageFlows extends BasePage {
     }
 
     public void requestAuthSecurityCodeResendNumberOfTimes(
-                Integer numberOfTimes, Boolean isReauth) {
-            for (int i = 0; i < numberOfTimes; i++) {
-                checkYourPhonePage.clickProblemsWithTheCodeLink();
-                checkYourPhonePage.clickSendTheCodeAgainLink();
-                waitForPageLoad("Get security code");
-                if (isReauth) {
-                    waitForThisText("you will be signed out");
-                }
-                getSecurityCodePage.pressGetSecurityCodeButton();
-                System.out.println(
-                        "Code request count: "
-                                + (i + 1)
-                                + " ("
-                                + (i + 2)
-                                + " including code sent on initial entry to the Check Your Auth page)");
+            Integer numberOfTimes, Boolean isReauth) {
+        for (int i = 0; i < numberOfTimes; i++) {
+            checkYourPhonePage.clickProblemsWithTheCodeLink();
+            checkYourPhonePage.clickSendTheCodeAgainLink();
+            waitForPageLoad("Get security code");
+            if (isReauth) {
+                waitForThisText("you will be signed out");
             }
+            getSecurityCodePage.pressGetSecurityCodeButton();
+            System.out.println(
+                    "Code request count: "
+                            + (i + 1)
+                            + " ("
+                            + (i + 2)
+                            + " including code sent on initial entry to the Check Your Auth page)");
+        }
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/LoginStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/LoginStepDef.java
@@ -414,4 +414,17 @@ public class LoginStepDef extends BasePage {
                 throw new RuntimeException("Invalid mfa type: " + mfaType);
         }
     }
+
+    @When("the user requests the auth otp code a further {int} times")
+    public void theUserRequestsTheAuthOtpCodeAFurtherTimes(Integer timesCodeIncorrect) {
+        crossPageFlows.requestAuthSecurityCodeResendNumberOfTimes(timesCodeIncorrect, false);
+    }
+
+    @And("the user enters the security code from backup MFA auth app")
+    public void theUserEntersTheSecurityCodeFromBackupMFAAuthApp() {
+        if (authAppSecretKey == null) {
+            authAppSecretKey = world.userCredentials.getMfaMethods().get(1).getCredentialValue();
+        }
+        setUpAnAuthenticatorAppPage.enterCorrectAuthAppCodeAndContinue(authAppSecretKey);
+    }
 }

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/Login/using-back-up-mfa.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/Login/using-back-up-mfa.feature
@@ -290,3 +290,109 @@ Feature: Login Using Back Up MFA
     Then the user is taken to the "Check your phone" page
     When the user enters an incorrect phone security code 6 times
     Then the user is taken to the "You entered the wrong security code too many times" page
+
+  @AUT-4183
+  Scenario: User with SMS as the default MFA method attempts password reset authentication using correct OTP sent an backup Auth App
+    Given a Migrated User with a Default MFA of SMS
+    And the User is Authenticated
+    And the User does not have a Backup MFA method
+    When the User requests to add a backup MFA Auth App
+    Then the User's back up MFA Auth App is updated
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
+    When the user enters their email address
+    Then the user is taken to the "Enter your password" page
+    When the user clicks the forgotten password link
+    Then the user is taken to the "Check your email" page
+    When the user enters the six digit security code from their email
+    Then the user is taken to the "Check your phone" page
+    And the user selects "Problems with the code?" link
+    And the user selects "try another way to get a security code" link
+    Then the user is taken to the "How do you want to get a security code?" page
+    When the user selects radio button "Use your authenticator app"
+    Then the user is taken to the "Enter a security code from your authenticator app" page
+    And the user enters the security code from backup MFA auth app
+    Then the user is taken to the "Reset your password" page
+    When the user enters valid new password and correctly retypes it
+    Then the user is returned to the service
+
+  @AUT-4183
+  Scenario: User with Auth App as the default MFA method attempts password reset authentication using correct OTP sent an backup SMS
+    Given a Migrated User with an Auth App Default MFA
+    And the User is Authenticated
+    And the User does not have a Backup MFA method
+    When the User adds "07700900111" as their SMS Backup MFA
+    Then the system sends an OTP to "07700900111"
+    When the User provides the correct otp
+    Then "07700900111" is added as a verified Backup MFA Method
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
+    When the user enters their email address
+    Then the user is taken to the "Enter your password" page
+    When the user clicks the forgotten password link
+    Then the user is taken to the "Check your email" page
+    When the user enters the six digit security code from their email
+    Then the user is taken to the "Enter a security code from your authenticator app" page
+    When the user selects "I do not have access to the authenticator app" link
+    And the user selects "try another way to get a security code" link
+    Then the user is taken to the "How do you want to get a security code?" page
+    And the user selects radio button "Text message to your phone number ending with" and "111"
+    When the user clicks the continue button
+    Then the user is taken to the "Check your phone" page
+    When the user enters the six digit security code from their phone
+    Then the user is taken to the "Reset your password" page
+    When the user enters valid new password and correctly retypes it
+    Then the user is returned to the service
+
+  @AUT-4183
+  Scenario: User with Auth App as the default MFA method attempts reset password authentication with backup SMS MFA and request OTP more than five times
+    Given a Migrated User with an Auth App Default MFA
+    And the User is Authenticated
+    And the User does not have a Backup MFA method
+    When the User adds "07700900111" as their SMS Backup MFA
+    Then the system sends an OTP to "07700900111"
+    When the User provides the correct otp
+    Then "07700900111" is added as a verified Backup MFA Method
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
+    When the user enters their email address
+    Then the user is taken to the "Enter your password" page
+    When the user clicks the forgotten password link
+    Then the user is taken to the "Check your email" page
+    When the user enters the six digit security code from their email
+    Then the user is taken to the "Enter a security code from your authenticator app" page
+    When the user selects "I do not have access to the authenticator app" link
+    And the user selects "try another way to get a security code" link
+    Then the user is taken to the "How do you want to get a security code?" page
+    And the user selects radio button "Text message to your phone number ending with" and "111"
+    When the user clicks the continue button
+    Then the user is taken to the "Check your phone" page
+    When the user requests the phone otp code a further 5 times
+    Then the user is taken to the "You asked to resend the security code too many times" page
+
+  @AUT-4183
+  Scenario: User with SMS as the default MFA method attempts password reset authentication with Auth App and enters incorrect OTP more than five times
+    Given a Migrated User with a Default MFA of SMS
+    And the User is Authenticated
+    And the User does not have a Backup MFA method
+    When the User requests to add a backup MFA Auth App
+    Then the User's back up MFA Auth App is updated
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
+    When the user enters their email address
+    Then the user is taken to the "Enter your password" page
+    When the user clicks the forgotten password link
+    Then the user is taken to the "Check your email" page
+    When the user enters the six digit security code from their email
+    Then the user is taken to the "Check your phone" page
+    And the user selects "Problems with the code?" link
+    And the user selects "try another way to get a security code" link
+    Then the user is taken to the "How do you want to get a security code?" page
+    When the user selects radio button "Use your authenticator app"
+    Then the user is taken to the "Enter a security code from your authenticator app" page
+    When the user enters an incorrect auth app security code 6 times
+    Then the user is taken to the "You entered the wrong security code too many times" page


### PR DESCRIPTION
AUT-4183 User selects backup MFA to reset pasword

Scnario's. covered

1. Auth Default Backup SMS reset passord using backup MFA successfully 
2. SMS Default Backup Auth App reset passord using backup MFA successfully 
3. Error Screen for trying incorrect OTP for backup MFA 6 times
4. Error Screen for requesting OTP for backup MFA 6 times
