### PR TITLE
Aut 4199/back up mfa uplift

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/Hooks.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/Hooks.java
@@ -34,6 +34,11 @@ public class Hooks extends BasePage {
         AxeStepDef.thereAreNoAccessibilityViolations();
     }
 
+    @After
+    public void afterEach() {
+        Driver.get().manage().deleteAllCookies();
+    }
+
     @After("@UI")
     public void takeScreenshotOnFailure(Scenario scenario) {
         if (scenario.isFailed()) {

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/Login/using-back-up-mfa.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/Login/using-back-up-mfa.feature
@@ -396,3 +396,56 @@ Feature: Login Using Back Up MFA
     Then the user is taken to the "Enter a security code from your authenticator app" page
     When the user enters an incorrect auth app security code 6 times
     Then the user is taken to the "You entered the wrong security code too many times" page
+
+  @AUT-4199
+  Scenario: User with SMS as Default MFA and SMS as backup MFA switches MFA in uplift journey
+    Given a Migrated User with a Default MFA of SMS
+    And the User is Authenticated
+    And the User does not have a Backup MFA method
+    When the User adds "07700900111" as their SMS Backup MFA
+    Then the system sends an OTP to "07700900111"
+    When the User provides the correct otp
+    Then "07700900111" is added as a verified Backup MFA Method
+    When the user comes from the stub relying party with option 2fa-off and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
+    When the user enters their email address
+    Then the user is taken to the "Enter your password" page
+    When the user enters their password
+    Then the user is returned to the service
+    When the user comes from the stub relying party with options: [2fa-on,authenticated-2] and is taken to the "Enter a security code to continue" page
+    Then the user is taken to the "Enter a security code to continue" page
+    And the user selects "Problems with the code?" link
+    And the user selects "try another way to get a security code" link
+    Then the user is taken to the "How do you want to get a security code?" page
+    And the user selects radio button "Text message to your phone number ending with" and "111"
+    When the user clicks the continue button
+    Then the user is taken to the "Enter a security code to continue" page
+    When the user enters the six digit security code from their phone
+    Then the user is returned to the service
+
+  @AUT-4199
+  Scenario: User with Auth App as Default MFA and SMS as backup MFA switches MFA in uplift journey
+    Given a Migrated User with an Auth App Default MFA
+    And the User is Authenticated
+    And the User does not have a Backup MFA method
+    When the User adds "07700900111" as their SMS Backup MFA
+    Then the system sends an OTP to "07700900111"
+    When the User provides the correct otp
+    Then "07700900111" is added as a verified Backup MFA Method
+    When the user comes from the stub relying party with option 2fa-off and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
+    When the user enters their email address
+    Then the user is taken to the "Enter your password" page
+    When the user enters their password
+    Then the user is returned to the service
+    When the user comes from the stub relying party with options: [2fa-on,authenticated-2] and is taken to the "Enter a security code to continue" page
+    Then the user is taken to the "Enter a security code to continue" page
+    And the user selects "try another way to get a security code" link
+    Then the user is taken to the "How do you want to get a security code?" page
+    And the user selects radio button "Text message to your phone number ending with" and "111"
+    When the user clicks the continue button
+    Then the user is taken to the "Enter a security code to continue" page
+    When the user enters the six digit security code from their phone
+    Then the user is returned to the service


### PR DESCRIPTION
## What

- Adds acceptance tests for when a user with 2 migrated mfa methods goes
  through an uplift journey, from this ticket onwards they will be see
  the 'try another way' prompt on the enter code screen instead of the
  'check if you can change how you get security codes' prompt
- I've also added an @after hook that deletes all cookies. This is because
  the user session was persisting between test cases. This change resolves this.
- - In future, might be a good idea to consolidate Hooks logic

## How to review

1. Code Review
2. Run against AUT-4199/back-up-mfa-uplift FE repo branch
- - - Both locally and in dev pipeline

## Related PRs

https://github.com/govuk-one-login/authentication-acceptance-tests/pull/683
