### PR TITLE
BAU: Fix exit status from run scripts

### DIFF
--- a/docker/run-tests-api.sh
+++ b/docker/run-tests-api.sh
@@ -46,7 +46,6 @@ copy_test_reports() {
 
 execute_tests() {
   local acceptance_tests_exit_status
-  trap 'exit $acceptance_tests_exit_status' EXIT
 
   pushd /test > /dev/null || exit 1
   ./gradlew --no-daemon cucumber
@@ -54,6 +53,8 @@ execute_tests() {
   popd > /dev/null || exit 1
 
   copy_test_reports
+
+  return $acceptance_tests_exit_status
 }
 
 check_guard_conditions

--- a/docker/run-tests-ui.sh
+++ b/docker/run-tests-ui.sh
@@ -124,7 +124,6 @@ copy_test_reports() {
 
 execute_tests() {
   local acceptance_tests_exit_status
-  trap 'exit $acceptance_tests_exit_status' EXIT
 
   pushd /test > /dev/null || exit 1
   ./gradlew --no-daemon cucumber
@@ -132,6 +131,8 @@ execute_tests() {
   popd > /dev/null || exit 1
 
   copy_test_reports
+
+  return $acceptance_tests_exit_status
 }
 
 check_guard_conditions


### PR DESCRIPTION
When running on the pipeline the TRAP command
doesn't work.  Switch to using an explicit return.

## What

<!-- Describe what you have changed and why -->

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
