### PR TITLE
BAU: Add pre-merge checks for dependabot

### DIFF
--- a/.github/workflows/pre-merge-dependabot.yaml
+++ b/.github/workflows/pre-merge-dependabot.yaml
@@ -1,0 +1,29 @@
+name: Dependabot only pre-merge Check
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 #v4.7.1
+        with:
+          java-version: '17'
+          distribution: 'corretto'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@8379f6a1328ee0e06e2bb424dadb7b159856a326 # v4.4.0
+        with:
+          cache-read-only: false
+          add-job-summary: never
+
+      - name: Gradle build
+        run: ./gradlew build


### PR DESCRIPTION
## What

Other pre-merge and pre-commit checks were being skipped entirely for dependabot PRs. This meant that dependabot PRs weren't being checked to build in GHA. This new GHA yaml fixes that.

## How to review

1. Code Review
