### PR TITLE
Revert "AUT-4334: Enable test for device intelligence cookie"

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/Cookies.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/Cookies.feature
@@ -2,6 +2,7 @@
 Feature: Cookies
   The correct cookies are set on the browser, at the correct time
 
+  @under-development @AUT-4233
   Scenario: User views the start page
     Given the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
     Then the "di-device-intelligence" cookie has been set


### PR DESCRIPTION
## What

This reverts commit 974141081d3df492ca5f9bbd03c73bf04ab00826 (enabling the device intelligence cookie test), due to the test failing in the pipeline. Will revert, investigate, fix, and re-enable.