### PR TITLE
BAU: minor improvements to rundocker.sh

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Reformat README.md (prettier)
+55c73b5274d23f79de756319cb1a4859c19643c2

--- a/README.md
+++ b/README.md
@@ -3,12 +3,14 @@
 A comprehensive automated testing suite for validating the GOV.UK One Login authentication and account management functionality through both UI and API acceptance tests using Cucumber.
 
 The test suite consists of two main types of tests:
+
 - UI Tests: Browser-based end-to-end tests using Selenium WebDriver to validate user journeys through the web interface
 - API Tests: Direct validation of account management functionality by interacting with AWS services that back the private APIs
 
 The API tests work around the limitation of not being able to directly call the private APIs by interacting with the underlying AWS services (DynamoDB, Lambda, etc.) through the AWS SDK. This approach allows testing of account management features like MFA method updates and user profile changes by manipulating the same backend services that the APIs use.
 
 Key features include:
+
 - End-to-end testing of user registration and authentication flows
 - Multifactor authentication testing via both UI and API (SMS and authenticator app)
 - Account recovery and password reset validation
@@ -20,10 +22,12 @@ Key features include:
 - Welsh language support testing
 
 TODO:
+
 - Add details of running in the authdev environment.
 - Add details about ad-hoc test runs via the AWS Console
 
 ## Repository Structure
+
 ```
 .
 ├── acceptance-tests/          # Main test implementation directory
@@ -44,6 +48,7 @@ TODO:
 ## Quick Start
 
 ### Prerequisites
+
 - Java 17 JDK
 - Docker and Docker Compose
 - AWS CLI configured with appropriate credentials
@@ -53,31 +58,37 @@ TODO:
 ### Installation
 
 1. Clone the repository:
+
 ```bash
 git clone <repository-url>
 cd gov-uk-one-login-acceptance-tests
 ```
 
 2. Install dependencies:
+
 ```bash
 ./gradlew build
 ```
 
 3. Configure AWS credentials:
+
 ```bash
 aws configure
 ```
+
 ### Run The Tests
 
 The preferred way to run the tests is using the rundocker.sh script. Due to the two-account structure per environment, `UI` and `API`, tests must be run separately against their respective accounts:
 
 For UI Tests:
+
 ```bash
 # Run UI tests against dev environment
 ./rundocker.sh dev-ui
 ```
 
 For API Tests:
+
 ```bash
 # Run API tests against dev environment
 ./rundocker.sh dev-api
@@ -89,17 +100,19 @@ For API Tests:
 
 The scripts support running tests with either Chrome or Firefox browsers by specifying the browser as a second argument (e.g., `./rundocker.sh dev-ui chrome`).
 
-Test reports can be found in the tmp folder within the project.  Note: this folder can fill up quickly so regular purging is recommended.
+Test reports can be found in the tmp folder within the project. Note: this folder can fill up quickly so regular purging is recommended.
 
 #### AWS Environment Account Structure
 
 The deployment infrastructure uses separate AWS accounts for API and UI components in each environment:
 
 - Development Environment:
+
   - API deployment: di-auth-development account
   - UI deployment: di-authentication-development account
 
 - Build Environment:
+
   - API deployment: gds-di-development account
   - UI deployment: di-authentication-build account
 
@@ -111,9 +124,9 @@ The CUCUMBER_FILTER_TAGS define in each environment broadly focus on features ta
 
 #### Environmental Configuration
 
-The acceptance tests require various environment specific variables.  These variables are stored in AWS Systems Manager (SSM) Parameter Store.
+The acceptance tests require various environment specific variables. These variables are stored in AWS Systems Manager (SSM) Parameter Store.
 
-The names of the parameters follow a standard pattern: `/acceptance-tests/${ENVIRONMENT}/variable_name`.  Examples are:
+The names of the parameters follow a standard pattern: `/acceptance-tests/${ENVIRONMENT}/variable_name`. Examples are:
 
 ```shell
 /acceptance-tests/dev/CUCUMBER_FILTER_TAGS
@@ -128,6 +141,7 @@ To run the tests from the commandline use the `rundocker.sh` script with a param
 tests to run and in which account.
 
 For UI Tests:
+
 ```bash
 # Run UI tests against dev environment
 ./rundocker.sh dev-ui
@@ -138,6 +152,7 @@ For UI Tests:
 ```
 
 For API Tests:
+
 ```bash
 # Run API tests against dev environment
 ./rundocker.sh dev-api
@@ -147,7 +162,7 @@ For API Tests:
 ./rundocker.sh staging-api
 ```
 
-The scripts that execute inside the docker container retrieve all parameters from SSM and export them as environment variables. This ensures consistent configuration across different environments and secure storage of sensitive values.  See the following for details:
+The scripts that execute inside the docker container retrieve all parameters from SSM and export them as environment variables. This ensures consistent configuration across different environments and secure storage of sensitive values. See the following for details:
 
 ```shell
 docker/run-tests-api.sh
@@ -156,14 +171,14 @@ docker/run-tests-ui.sh
 
 Tests can be against either the UI or API account in any of the following environments:
 
-* dev
-* build
-* staging
+- dev
+- build
+- staging
 
 #### Overriding Environment Variables
 
-When running locally it can be helpful to limit the number of tests being executed.  This can be achieved
-by providing a local file of overridden values.  There is an override file for each type of test:
+When running locally it can be helpful to limit the number of tests being executed. This can be achieved
+by providing a local file of overridden values. There is an override file for each type of test:
 
 1. env-override-api.env
 2. env-override-ui.env
@@ -174,7 +189,7 @@ For example if you want to run a sub-set of tests:
 CUCUMBER_FILTER_TAGS="not (@AccountInterventions or @Reauth or @old-mfa-without-ipv)"
 ```
 
-Note.  See the [cucumber docs](https://cucumber.io/docs/cucumber/api/#tags) for how tom define multiple filter tags.
+Note. See the [cucumber docs](https://cucumber.io/docs/cucumber/api/#tags) for how tom define multiple filter tags.
 
 Or if you want to run with additional con-currency:
 
@@ -182,30 +197,30 @@ Or if you want to run with additional con-currency:
 PARALLEL_BROWSERS=2
 ```
 
-Note.  For the UI tests be cautious when overriding PARALLEL_BROWSERS as the number to use is already calculated dynamically in the scripts.
+Note. For the UI tests be cautious when overriding PARALLEL_BROWSERS as the number to use is already calculated dynamically in the scripts.
 
 ### Running the tests from an IDE
 
-IntelliJ is the preferred IDE on the auth team.  It allows individual tests to be run directly from the
+IntelliJ is the preferred IDE on the auth team. It allows individual tests to be run directly from the
 editor and it allows the step definitions to be run in the debugger.
 
-In order to run tests in IntelliJ you will need to update the run template to refer to a local .env file.  This
+In order to run tests in IntelliJ you will need to update the run template to refer to a local .env file. This
 file provides a small number of environment variables to the test execution environment:
 
-| Environment Variable | Example Value                | Purpose                                                                                                                           |
-|----------------------|------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
-| SELENIUM_URL         | http://localhost:4445/wd/hub | Local selenium server firefox = 4444, chrome = 4445                                                                               |
-| SELENIUM_BROWSER     | chrome                       | Browser used to run tests - firefox or chrome                                                                                     |
-| SELENIUM_LOCAL       | true                         |                                                                                                                                   |
-| SELENIUM_HEADLESS    | true                         | Run Selenium headless.                                                                                                            |
-| USE_SSM              | true                         | Specifically for running from the IDE.  Tells the test runner to use SSM if a required environment variable is undefined locally. |
-| DEBUG_MODE           | false                        | debug mode waits for user entry on OTP screens so you can enter OTP yourself.                                                     |
-| ACCESSIBILITY_CHECKS | false                        |                                                                                                                                   |
-| FAIL_FAST_ENABLED    | false                        |                                                                                                                                   |
-| PARALLEL_BROWSERS    | 1                            |                                                                                                                                   |
-| CUCUMBER_FILTER_TAGS | "@API"                       |                                                                                                                                   |
-| AWS_PROFILE          | di-auth-development-admin    |                                                                                                                                   |
-| ENVIRONMENT          | dev                          |                                                                                                                                   |
+| Environment Variable | Example Value                | Purpose                                                                                                                          |
+| -------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| SELENIUM_URL         | http://localhost:4445/wd/hub | Local selenium server firefox = 4444, chrome = 4445                                                                              |
+| SELENIUM_BROWSER     | chrome                       | Browser used to run tests - firefox or chrome                                                                                    |
+| SELENIUM_LOCAL       | true                         |                                                                                                                                  |
+| SELENIUM_HEADLESS    | true                         | Run Selenium headless.                                                                                                           |
+| USE_SSM              | true                         | Specifically for running from the IDE. Tells the test runner to use SSM if a required environment variable is undefined locally. |
+| DEBUG_MODE           | false                        | debug mode waits for user entry on OTP screens so you can enter OTP yourself.                                                    |
+| ACCESSIBILITY_CHECKS | false                        |                                                                                                                                  |
+| FAIL_FAST_ENABLED    | false                        |                                                                                                                                  |
+| PARALLEL_BROWSERS    | 1                            |                                                                                                                                  |
+| CUCUMBER_FILTER_TAGS | "@API"                       |                                                                                                                                  |
+| AWS_PROFILE          | di-auth-development-admin    |                                                                                                                                  |
+| ENVIRONMENT          | dev                          |                                                                                                                                  |
 
 ## Deployment
 
@@ -215,11 +230,13 @@ The acceptance tests are deployed using GitHub Actions workflows. To deploy the 
 2. Use the "Build and Push to UI DEV account" workflow to deploy them to the UI environment
 
 The workflow will:
+
 - Build the test containers for both Chrome and Firefox browsers
 - Push the images to the development ECR repository
 - Tag the images appropriately for use in the development environment
 
 ## Data Flow
+
 The acceptance tests interact with multiple components to validate the GOV.UK One Login service functionality.
 
 ```ascii
@@ -231,6 +248,7 @@ The acceptance tests interact with multiple components to validate the GOV.UK On
 ```
 
 Component Interactions:
+
 - Test Runner executes Cucumber feature files
 - Selenium WebDriver controls browser interactions
 - Page Objects abstract UI interactions

--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ For API Tests:
 
 ### Overview
 
-The scripts support running tests with either Chrome or Firefox browsers by specifying the browser as a second argument (e.g., `./rundocker.sh dev-ui chrome`).
+The scripts primarily support running the tests in Chromium.
+
+Firefox (or maybe even Edge) can be used by passing the full reference of a `selenium/standalone-*` image [list here](https://hub.docker.com/u/selenium?page=1&search=standalone) as a second CLI argument. For example: `./rundocker.sh dev-ui selenium/standalone-firefox:136.0`.
 
 Test reports can be found in the tmp folder within the project. Note: this folder can fill up quickly so regular purging is recommended.
 


### PR DESCRIPTION
## What

- Instead of partially hardcoding the selenium base image, instead allow
  the user to specify the whole image name + version as an argument.
  This ensures that if no image is specified, the default _from the
  Dockerfile_ is used. As-was, we would have to remember to bump the
  version both in this script and the Dockerfile, which is error-prone.
- Remove `--privileged` flag from `docker run` commands, as it is not
  needed for these tests and can pose security risks.

WRT the base image, I could have added some guardrails to prevent people using inappropriate base images, but it'll become very clear when the tests don't work. It's unlikely this flag will be used very often.

## How to review

Run the script with/without a specified base image - check tests work as expected (spurious AT failures don't necessarily mean this PR is invalid)

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
