### PR TITLE
AUT-4315- To validate Update rules for phone number

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
@@ -1,5 +1,7 @@
 package uk.gov.di.test.step_definitions;
 
+import io.cucumber.core.internal.com.fasterxml.jackson.databind.JsonNode;
+import io.cucumber.core.internal.com.fasterxml.jackson.databind.ObjectMapper;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
@@ -14,7 +16,7 @@ import uk.gov.di.test.pages.StubUserInfoPage;
 import uk.gov.di.test.utils.Driver;
 
 import java.util.List;
-
+import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.*;
 import static uk.gov.di.test.utils.Driver.getDriver;
 
@@ -24,6 +26,11 @@ public class CommonStepDef extends BasePage {
     public StubUserInfoPage stubUserInfoPage = StubUserInfoPage.getStubUserInfoPage();
     StubStartPage stubStartPage = StubStartPage.getStubStartPage();
     private final World world;
+    //private byte[] userInfoJson;
+    private String userInfoJson;
+    public void setUserInfoJson(String json) {
+        this.userInfoJson = json;
+    }
 
     public CommonStepDef(World world) {
         this.crossPageFlows = new CrossPageFlows(world);
@@ -188,4 +195,29 @@ public class CommonStepDef extends BasePage {
     public void theUserClicksTheContinueButtonWithoutSelectingAnyRadioButtonOption() {
         findAndClickContinue();
     }
-}
+
+    @And("the {string} is {word}")
+    public void theClaimIs(String claimName, String expectedValue) throws Exception {
+        if (userInfoJson == null) {
+            throw new IllegalStateException("User info JSON has not been set before validating claims.");
+        }
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(userInfoJson);
+
+        boolean actual = root.get(claimName).asBoolean();
+        boolean expected = Boolean.parseBoolean(expectedValue);
+
+        assertEquals("Expected '" + claimName + "' to be " + expected, expected, actual);
+    }
+
+    @And("the user info JSON is extracted from the stub page")
+    public void extractUserInfoJsonFromStubPage() {
+        String json = Driver.get()
+                .findElement(By.xpath("//*[@id='main-content']/dl/div[2]/dd"))
+                .getText();
+
+        setUserInfoJson(json);
+    }
+
+    }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
@@ -26,7 +26,6 @@ public class CommonStepDef extends BasePage {
     public StubUserInfoPage stubUserInfoPage = StubUserInfoPage.getStubUserInfoPage();
     StubStartPage stubStartPage = StubStartPage.getStubStartPage();
     private final World world;
-    //private byte[] userInfoJson;
     private String userInfoJson;
     public void setUserInfoJson(String json) {
         this.userInfoJson = json;
@@ -219,5 +218,4 @@ public class CommonStepDef extends BasePage {
 
         setUserInfoJson(json);
     }
-
     }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
@@ -16,6 +16,7 @@ import uk.gov.di.test.pages.StubUserInfoPage;
 import uk.gov.di.test.utils.Driver;
 
 import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.*;
 import static uk.gov.di.test.utils.Driver.getDriver;
@@ -27,6 +28,7 @@ public class CommonStepDef extends BasePage {
     StubStartPage stubStartPage = StubStartPage.getStubStartPage();
     private final World world;
     private String userInfoJson;
+
     public void setUserInfoJson(String json) {
         this.userInfoJson = json;
     }
@@ -198,7 +200,8 @@ public class CommonStepDef extends BasePage {
     @And("the {string} is {word}")
     public void theClaimIs(String claimName, String expectedValue) throws Exception {
         if (userInfoJson == null) {
-            throw new IllegalStateException("User info JSON has not been set before validating claims.");
+            throw new IllegalStateException(
+                    "User info JSON has not been set before validating claims.");
         }
 
         ObjectMapper mapper = new ObjectMapper();
@@ -212,10 +215,11 @@ public class CommonStepDef extends BasePage {
 
     @And("the user info JSON is extracted from the stub page")
     public void extractUserInfoJsonFromStubPage() {
-        String json = Driver.get()
-                .findElement(By.xpath("//*[@id='main-content']/dl/div[2]/dd"))
-                .getText();
+        String json =
+                Driver.get()
+                        .findElement(By.xpath("//*[@id='main-content']/dl/div[2]/dd"))
+                        .getText();
 
         setUserInfoJson(json);
     }
-    }
+}

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/Login/using-back-up-mfa.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/Login/using-back-up-mfa.feature
@@ -532,3 +532,96 @@ Feature: Login Using Back Up MFA
     Then the user is forcibly logged out
     * the user is not blocked from signing in
     * the user is not blocked from reauthenticating
+
+
+  @AUT-4315
+  Scenario: Migrated User with SMS as Default MFA and SMS as backup MFA to validate default phone number for claim
+    Given a Migrated User with a Default MFA of SMS
+    And the User is Authenticated
+    And the User does not have a Backup MFA method
+    When the User adds "+447700900111" as their SMS Backup MFA
+    Then the system sends an OTP to "07700900111"
+    When the User provides the correct otp
+    Then "+447700900111" is added as a verified Backup MFA Method
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
+    When the user enters their email address
+    Then the user is taken to the "Enter your password" page
+    When the user enters their password
+    Then the user is taken to the "Check your phone" page
+    When the user enters the six digit security code from their phone
+    Then the user is returned to the service
+    And the user info JSON is extracted from the stub page
+    And the "phone_number_verified" is true
+
+  @AUT-4315
+  Scenario: Migrated User with SMS as Default MFA and Auth App as backup MFA to validate default phone number for claim
+    Given a Migrated User with a Default MFA of SMS
+    And the User is Authenticated
+    And the User does not have a Backup MFA method
+    When the User requests to add a backup MFA Auth App
+    Then the User's back up MFA Auth App is updated
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
+    When the user enters their email address
+    Then the user is taken to the "Enter your password" page
+    When the user enters their password
+    Then the user is taken to the "Check your phone" page
+    When the user enters the six digit security code from their phone
+    Then the user is returned to the service
+    And the user info JSON is extracted from the stub page
+    And the "phone_number_verified" is true
+
+  @AUT-4315
+  Scenario: Migrated User with Auth APP as Default MFA and SMS as backup MFA to validate default phone number for claim
+    Given a Migrated User with an Auth App Default MFA
+    And the User is Authenticated
+    And the User does not have a Backup MFA method
+    When the User adds "+447700900111" as their SMS Backup MFA
+    Then the system sends an OTP to "07700900111"
+    When the User provides the correct otp
+    Then "+447700900111" is added as a verified Backup MFA Method
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
+    When the user enters their email address
+    Then the user is taken to the "Enter your password" page
+    When the user enters their password
+    Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
+    When the user enters the six digit code for "App"
+    Then the user is returned to the service
+    And the user info JSON is extracted from the stub page
+    And the "phone_number_verified" is false
+
+  @AUT-4315
+  Scenario: Non-Migrated User with APP as Default MFA and no backup to validate default phone number for claim
+    Given a user with App MFA exists
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
+    When the user enters their email address
+    Then the user is taken to the "Enter your password" page
+    When the user enters their password
+    Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
+    When the user enters the six digit code for "App"
+    Then the user is returned to the service
+    And the user info JSON is extracted from the stub page
+    And the "phone_number_verified" is false
+
+
+  @AUT-4315
+  Scenario: Non-Migrated User with SMS as Default MFA and no backup to validate default phone number for claim
+    Given a user with SMS MFA exists
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
+    When the user enters their email address
+    Then the user is taken to the "Enter your password" page
+    When the user enters their password
+    Then the user is taken to the "Check your phone" page
+    When the user enters the six digit security code from their phone
+    Then the user is returned to the service
+    And the user info JSON is extracted from the stub page
+    And the "phone_number_verified" is true


### PR DESCRIPTION
This PR updates the logic for the phone_number_verified claims in the auth user-info response, based on changes to how default and backup MFA methods are handled.

Previously, only SMS MFA users had their phone number included, and it was blank for Auth App users. With upcoming changes allowing default/backup combinations, only the default MFA method will determine whether a phone number is returned.
