### PR TITLE
Revert "BAU: Enable first API test in build"

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/api/account-management/account_management.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/api/account-management/account_management.feature
@@ -1,4 +1,4 @@
-@API
+@API @under-development
 Feature: Account Management
 
   Scenario Outline: Authenticated User successfully changes their Phone Number


### PR DESCRIPTION
Reverts govuk-one-login/authentication-acceptance-tests#704

Tests are currently failing in the pipeline

'is not authorized to perform: kms:Sign on resource'