### PR TITLE
AUT-4509: Update title to match new Ts&Cs page

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/account_interventions.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/account_interventions.feature
@@ -42,7 +42,7 @@ Feature: Account interventions
     When the user enters their password
     Then the user is taken to the "Check your phone" page
     When the user enters the six digit security code from their phone
-    Then the user is taken to the "terms of use update" page
+    Then the user is taken to the "We’ve updated our terms of use" page
     When the user agrees to the updated terms and conditions
     Then the user is taken to the "Sorry, there is a problem" page
 
@@ -192,7 +192,7 @@ Feature: Account interventions
     When the user enters their password
     Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
     When the user enters the security code from the auth app
-    Then the user is taken to the "terms of use update" page
+    Then the user is taken to the "We’ve updated our terms of use" page
     When the user agrees to the updated terms and conditions
     Then the user is taken to the "Your GOV.UK One Login has been permanently locked" page
 
@@ -414,7 +414,7 @@ Feature: Account interventions
     When the user enters their password
     Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
     When the user enters the security code from the auth app
-    Then the user is taken to the "terms of use update" page
+    Then the user is taken to the "We’ve updated our terms of use" page
     When the user agrees to the updated terms and conditions
     Then the user is taken to the "You need to reset your password" page
     When the user clicks the continue button


### PR DESCRIPTION
## What

The title was changed from "GOV.UK One Login terms of use update" to "We’ve updated our terms of use" so a test has been updated to match.

## How to review

1. Code Review

## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/2874