### PR TITLE
BAU: bump cosign release version 1.9.0 -> 2.5.3

### DIFF
--- a/.github/workflows/build-and-push-tests-SP-dev.yaml
+++ b/.github/workflows/build-and-push-tests-SP-dev.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
         with:
-          cosign-release: "v1.9.0"
+          cosign-release: "v2.5.3"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1

--- a/.github/workflows/build-and-push-tests-SP.yaml
+++ b/.github/workflows/build-and-push-tests-SP.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
         with:
-          cosign-release: "v1.9.0"
+          cosign-release: "v2.5.3"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1


### PR DESCRIPTION
## What

BAU: bump cosign release version 1.9.0 -> 2.5.3
Cosign v1.9.0 is no longer supported

## How to review

Tested with deploying to dev UI