### PR TITLE
Email blocks

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/CannotUseEmailAddressPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/CannotUseEmailAddressPage.java
@@ -1,0 +1,41 @@
+package uk.gov.di.test.pages;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import uk.gov.di.test.utils.Driver;
+
+public class CannotUseEmailAddressPage extends BasePage {
+
+    private static final String PATH = "/cannot-use-email-address";
+
+    private final By h1 = By.cssSelector("h1");
+    private final By bodyText = By.cssSelector("#main-content .govuk-grid-column-two-thirds");
+    private final By tryAnotherEmailLink = By.linkText("try another email address");
+
+    @Override
+    public void waitForPage() {
+        WebDriverWait wait = new WebDriverWait(Driver.get(), DEFAULT_PAGE_LOAD_WAIT_TIME);
+        wait.until(ExpectedConditions.urlContains(PATH));
+        wait.until(ExpectedConditions.visibilityOfElementLocated(h1));
+    }
+
+    public String heading() {
+        return Driver.get().findElement(h1).getText();
+    }
+
+    public String screenText() {
+        WebElement el = Driver.get().findElement(bodyText);
+        return el.getText();
+    }
+
+    public void clickTryAnotherEmail() {
+        WebDriverWait wait = new WebDriverWait(Driver.get(), DEFAULT_PAGE_LOAD_WAIT_TIME);
+        wait.until(ExpectedConditions.elementToBeClickable(tryAnotherEmailLink)).click();
+    }
+
+    public static boolean matches(String url) {
+        return url != null && url.contains(PATH);
+    }
+}

--- a/acceptance-tests/src/test/java/uk/gov/di/test/services/UserLifecycleService.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/services/UserLifecycleService.java
@@ -64,6 +64,15 @@ public class UserLifecycleService {
         return sub.replace(emailAddressFormat);
     }
 
+    public String generateHighRiskEmailAddress() {
+        return String.format(
+                "test-user+%s-stubemailassessmentfailure@test.null.local", ENVIRONMENT);
+    }
+
+    public String generateHighRiskEmailAddressThatWillCauseAnError() {
+        return String.format("test-user+%s-stubemailassessmenterrore@test.null.local", ENVIRONMENT);
+    }
+
     private TermsAndConditions buildTermsAndConditions(String version) {
         return new TermsAndConditions(version, DEFAULT_TIMESTAMP);
     }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
@@ -42,7 +42,14 @@ public class CommonStepDef extends BasePage {
 
     String idToken;
 
+    @Then("the user email is not blocked")
+    public void emailNotBlocked() {
+        waitForPageLoad("Create your password");
+    }
+
+    @Then("the user email is accepted and the {string} page is presented")
     @Then("the user is taken to the {string} page")
+    @Then("the user email is blocked and the {string} page is presented")
     public void theUserIsTakenToThePage(String pageTitle) {
         waitForPageLoad(pageTitle);
     }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
@@ -44,7 +44,7 @@ public class CommonStepDef extends BasePage {
 
     String idToken;
 
-    @Then("the user email is not blocked")
+    @Then("the user email is not blocked to proceed with account creation")
     public void emailNotBlocked() {
         waitForPageLoad("Create your password");
     }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
@@ -11,12 +11,14 @@ import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.WebDriverWait;
 import uk.gov.di.test.pages.BasePage;
 import uk.gov.di.test.pages.CreateOrSignInPage;
 import uk.gov.di.test.pages.StubStartPage;
 import uk.gov.di.test.pages.StubUserInfoPage;
 import uk.gov.di.test.utils.Driver;
 
+import java.time.Duration;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -47,9 +49,8 @@ public class CommonStepDef extends BasePage {
         waitForPageLoad("Create your password");
     }
 
-    @Then("the user email is accepted and the {string} page is presented")
+    @Then("the user email is accepted and taken to {string} page")
     @Then("the user is taken to the {string} page")
-    @Then("the user email is blocked and the {string} page is presented")
     public void theUserIsTakenToThePage(String pageTitle) {
         waitForPageLoad(pageTitle);
     }
@@ -70,7 +71,7 @@ public class CommonStepDef extends BasePage {
     }
 
     @When("the user selects {string} link")
-    public void theUserSelectsProblemsWithTheCode(String text) {
+    public void theUserSelectsTheLink(String text) {
         selectLinkByText(text);
     }
 
@@ -183,13 +184,26 @@ public class CommonStepDef extends BasePage {
         waitForPageLoad(pageTitle);
     }
 
+    @Then("the user remain on the {string} page")
+    @Then("the user email is blocked and taken to {string} page")
     @Then("the URL is present with suffix {string}")
     public void theUrlIsPresentWithSuffix(String expectedSuffix) {
-        String currentUrl = getDriver().getCurrentUrl();
-        assertTrue(currentUrl.contains(expectedSuffix));
+        WebDriverWait wait = new WebDriverWait(getDriver(), Duration.ofSeconds(10));
+        Boolean urlContainsSuffix =
+                wait.until(
+                        driver ->
+                                driver.getCurrentUrl() != null
+                                        && driver.getCurrentUrl().contains(expectedSuffix));
+        assertTrue(
+                urlContainsSuffix,
+                "Expected URL to contain suffix: "
+                        + expectedSuffix
+                        + " but was: "
+                        + getDriver().getCurrentUrl());
     }
 
     @And("the user navigates to the previous page")
+    @And("the user attempt to navigates to the previous page")
     public void theUserNavigatesToThePreviousPage() {
         WebDriver driver = getDriver();
         driver.navigate().back();
@@ -261,5 +275,12 @@ public class CommonStepDef extends BasePage {
         }
 
         setUserInfoJson(json);
+    }
+
+    @And("the user clicks on {string} link")
+    public void TheUserClicksOnLink(String text) {
+        selectLinkByText(text);
+        {
+        }
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/LoginStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/LoginStepDef.java
@@ -35,6 +35,7 @@ public class LoginStepDef extends BasePage {
 
     StubStartPage stubStartPage = StubStartPage.getStubStartPage();
     private final World world;
+    private final UserLifecycleService userLifecycleService = UserLifecycleService.getInstance();
 
     private String authAppSecretKey;
 
@@ -87,13 +88,13 @@ public class LoginStepDef extends BasePage {
 
     @When("User enters a high-risk email")
     public void theUserEntersAHighRiskEmailAddress() {
-        var email = "test-user+dev-stubemailassessmentfailure@test.null.local";
+        var email = userLifecycleService.generateHighRiskEmailAddress();
         enterYourEmailAddressPage.enterEmailAddressAndContinue(email);
     }
 
     @When("User enters a high-risk email that will cause an error")
     public void theUserEntersAHighRiskEmailAddressThatWillCauseAnError() {
-        var email = "test-user+dev-stubemailassessmenterrore@test.null.local";
+        var email = userLifecycleService.generateHighRiskEmailAddressThatWillCauseAnError();
         enterYourEmailAddressPage.enterEmailAddressAndContinue(email);
     }
 

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/LoginStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/LoginStepDef.java
@@ -85,8 +85,15 @@ public class LoginStepDef extends BasePage {
         createOrSignInPage.clickSignInButton();
     }
 
-    @And("User enters an email {string}")
-    public void theUserEntersAnEmailAddress(String email) {
+    @When("User enters a high-risk email")
+    public void theUserEntersAHighRiskEmailAddress() {
+        var email = "test-user+dev-stubemailassessmentfailure@test.null.local";
+        enterYourEmailAddressPage.enterEmailAddressAndContinue(email);
+    }
+
+    @When("User enters a high-risk email that will cause an error")
+    public void theUserEntersAHighRiskEmailAddressThatWillCauseAnError() {
+        var email = "test-user+dev-stubemailassessmenterrore@test.null.local";
         enterYourEmailAddressPage.enterEmailAddressAndContinue(email);
     }
 

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/LoginStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/LoginStepDef.java
@@ -85,6 +85,11 @@ public class LoginStepDef extends BasePage {
         createOrSignInPage.clickSignInButton();
     }
 
+    @And("User enters an email {string}")
+    public void theUserEntersAnEmailAddress(String email) {
+        enterYourEmailAddressPage.enterEmailAddressAndContinue(email);
+    }
+
     @And("the user enters their email address")
     @And("the user enters the email address")
     public void theUserEntersTheirEmailAddress() {

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/email_blocks.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/email_blocks.feature
@@ -1,6 +1,9 @@
 @AUT-4388 @UI @dev @build @staging
 Feature: Create account - Experian email check
 
+  Experian is checking the submitted email address and a decision is made before the User is asked to create a password.
+  The scenarios check that email blocking is applied correctly.  See registration_journey.feature for full creation scenarios.
+
   Scenario: User successfully create an account with valid email using sms as OTP
     Given a user does not yet exist
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -9,38 +12,9 @@ Feature: Create account - Experian email check
     When the user enters their email address
     Then the user is taken to the "Check your email" page
     When the user enters the six digit security code from their email
-
-
-    Then the user is taken to the "Create your password" page
-    When the user creates a password
-    Then the user is taken to the "Choose how to get security codes" page
-    When the user chooses text message to get security codes
-    Then the user is taken to the "Enter your mobile phone number" page
-    When the user enters their mobile phone number
-    Then the user is taken to the "Check your phone" page
-    When the user enters the six digit security code from their phone
-    Then the user is taken to the "You’ve created your GOV.UK One Login" page
-    When the user clicks the continue button
-    Then the user is returned to the service
-
-
-  Scenario: User successfully create an account with valid email using Auth App as OTP
-    Given a user does not yet exist
-    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
-    When the user selects create an account
-    Then the user is taken to the "Enter your email address" page
-    When the user enters their email address
-    Then the user is taken to the "Check your email" page
-    When the user enters the six digit security code from their email
-    Then the user is taken to the "Create your password" page
-    When the user creates a password
-    When the user chooses auth app to get security codes
-    Then the user is taken to the "Set up an authenticator app" page
-    When the user adds the secret key on the screen to their auth app
-    And the user enters the security code from the auth app
-    Then the user is taken to the "You’ve created your GOV.UK One Login" page
-    When the user clicks the continue button
-    Then the user is returned to the service
+    # Pick one
+    Then the user email is accepted and the "Create your password" page is presented
+    Then the user email is not blocked
 
   @AUT-4389
   Scenario: User successfully create an account with valid email using sms as OTP
@@ -48,6 +22,7 @@ Feature: Create account - Experian email check
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
     When the user selects create an account
     Then the user is taken to the "Enter your email address" page
-    When the user enters their email address
+    When User enters an email "stubemailassessmenterror@test.null"
     Then the user is taken to the "Check your email" page
     When the user enters the six digit security code from their email
+    Then the user email is blocked and the "Sorry" page is presented

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/email_blocks.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/email_blocks.feature
@@ -1,0 +1,53 @@
+@AUT-4388 @UI @dev @build @staging
+Feature: Create account - Experian email check
+
+  Scenario: User successfully create an account with valid email using sms as OTP
+    Given a user does not yet exist
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects create an account
+    Then the user is taken to the "Enter your email address" page
+    When the user enters their email address
+    Then the user is taken to the "Check your email" page
+    When the user enters the six digit security code from their email
+
+
+    Then the user is taken to the "Create your password" page
+    When the user creates a password
+    Then the user is taken to the "Choose how to get security codes" page
+    When the user chooses text message to get security codes
+    Then the user is taken to the "Enter your mobile phone number" page
+    When the user enters their mobile phone number
+    Then the user is taken to the "Check your phone" page
+    When the user enters the six digit security code from their phone
+    Then the user is taken to the "You’ve created your GOV.UK One Login" page
+    When the user clicks the continue button
+    Then the user is returned to the service
+
+
+  Scenario: User successfully create an account with valid email using Auth App as OTP
+    Given a user does not yet exist
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects create an account
+    Then the user is taken to the "Enter your email address" page
+    When the user enters their email address
+    Then the user is taken to the "Check your email" page
+    When the user enters the six digit security code from their email
+    Then the user is taken to the "Create your password" page
+    When the user creates a password
+    When the user chooses auth app to get security codes
+    Then the user is taken to the "Set up an authenticator app" page
+    When the user adds the secret key on the screen to their auth app
+    And the user enters the security code from the auth app
+    Then the user is taken to the "You’ve created your GOV.UK One Login" page
+    When the user clicks the continue button
+    Then the user is returned to the service
+
+  @AUT-4389
+  Scenario: User successfully create an account with valid email using sms as OTP
+    Given a user does not yet exist
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects create an account
+    Then the user is taken to the "Enter your email address" page
+    When the user enters their email address
+    Then the user is taken to the "Check your email" page
+    When the user enters the six digit security code from their email

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/email_blocks.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/email_blocks.feature
@@ -1,10 +1,13 @@
-@AUT-4388 @UI @dev @build @staging
+@AUT-4388 @AUT-4389 @UI @dev @build @staging
 Feature: Create account - Experian email check
 
-  Experian is checking the submitted email address and a decision is made before the User is asked to create a password.
-  The scenarios check that email blocking is applied correctly.  See registration_journey.feature for full creation scenarios.
+  This scenario covers how Experian checks the email address submitted during One Login account creation.
+  The check runs in the background while the user enters their email OTP, and based on the result,
+  the system either allows a valid email to proceed to password creation or blocks a fraudulent or high-risk email
+  from opening an account. These scenarios confirm that the email-blocking logic works as intended,
+  while the existing Registration_journey.feature file validates the full end-to-end account creation journey.
 
-  Scenario: User successfully create an account with valid email using sms as OTP
+  Scenario: User can create an account with a valid email and not blocked by experian
     Given a user does not yet exist
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
     When the user selects create an account
@@ -12,17 +15,32 @@ Feature: Create account - Experian email check
     When the user enters their email address
     Then the user is taken to the "Check your email" page
     When the user enters the six digit security code from their email
-    # Pick one
-    Then the user email is accepted and the "Create your password" page is presented
+    And the user email is accepted and taken to "Create your password" page
     Then the user email is not blocked
 
-  @AUT-4389
-  Scenario: User successfully create an account with valid email using sms as OTP
+
+  Scenario: User can create an account with a high-risk email and not blocked by experian when the service is down
     Given a user does not yet exist
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
     When the user selects create an account
     Then the user is taken to the "Enter your email address" page
-    When User enters an email "stubemailassessmenterror@test.null"
+    When User enters a high-risk email that will cause an error
     Then the user is taken to the "Check your email" page
     When the user enters the six digit security code from their email
-    Then the user email is blocked and the "Sorry" page is presented
+    And the user email is accepted and taken to "Create your password" page
+    Then the user email is not blocked
+
+
+  Scenario: User get blocked while trying to create an account with high-risk email
+    Given a user does not yet exist
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects create an account
+    Then the user is taken to the "Enter your email address" page
+    When User enters a high-risk email
+    Then the user is taken to the "Check your email" page
+    When the user enters the six digit security code from their email
+    Then the user email is blocked and taken to "cannot-use-email-address" page
+    And the user attempt to navigates to the previous page
+    Then the user remain on the "cannot-use-email-address" page
+    And the user clicks on "try another email address" link
+    Then the user is taken to the "Enter your email address" page

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/email_blocks.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/email_blocks.feature
@@ -16,7 +16,7 @@ Feature: Create account - Experian email check
     Then the user is taken to the "Check your email" page
     When the user enters the six digit security code from their email
     And the user email is accepted and taken to "Create your password" page
-    Then the user email is not blocked
+    Then the user email is not blocked to proceed with account creation
 
 
   Scenario: User can create an account with a high-risk email and not blocked by experian when the service is down
@@ -28,7 +28,7 @@ Feature: Create account - Experian email check
     Then the user is taken to the "Check your email" page
     When the user enters the six digit security code from their email
     And the user email is accepted and taken to "Create your password" page
-    Then the user email is not blocked
+    Then the user email is not blocked to proceed with account creation
 
 
   Scenario: User get blocked while trying to create an account with high-risk email


### PR DESCRIPTION
This PR introduces automated acceptance tests for the fraudulent email blocking feature in GOV.UK One Login. The tests ensure that high-risk or known fraudulent email addresses are correctly identified and blocked during account creation and email updates, while genuine/valid emails continue to pass through as expected.

Key Changes:

Added Cucumber feature scenarios covering:

Successful account creation with a fraud-free email.

Blocking of account creation when a high-risk email is entered.

Bypass of email of a high-risk email when the service is down.

Verification of error messaging 

Step definitions updated to abstract test email values, keeping addresses out of feature files.

Page object methods extended to handle input and submission on the Enter Your Email Address page.

Test coverage aligned with acceptance criteria for the “Email blocks” initiative.

Purpose:

The purpose of these tests is to provide confidence that fraudulent or risky email addresses are detected and blocked at the right points in the user journey. This ensures that:

Users cannot create or update accounts using flagged addresses.

Legitimate users are not incorrectly blocked.

Error messaging is displayed clearly, consistently, and in the correct language.
