### PR TITLE
BAU: Bump netty-codec-http to 4.1.125.Final

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -38,6 +38,14 @@ dependencies {
     testImplementation libs.gson
 }
 
+dependencies {
+    constraints {
+        testImplementation('io.netty:netty-codec-http:[4.1.125.Final,)') {
+            because 'CVE-2025-58056 is fixed in io.netty:netty-codec-http:4.1.125.Final and higher'
+        }
+    }
+}
+
 group = 'uk.gov.di'
 version = '1.0-SNAPSHOT'
 description = 'acceptance-tests'


### PR DESCRIPTION
## What

Bump netty-codec-http to 4.1.125.Final

## How to review

1. Code Review