### PR TITLE
BAU: Bump apache.commons to 3.18.0

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -43,6 +43,9 @@ dependencies {
         testImplementation('io.netty:netty-codec-http:[4.1.125.Final,)') {
             because 'CVE-2025-58056 is fixed in io.netty:netty-codec-http:4.1.125.Final and higher'
         }
+        testImplementation('org.apache.commons:commons-lang3:[3.18.0,)') {
+            because 'CVE-2025-48924 is fixed in org.apache.commons:commons-lang3:3.18.0 and higher'
+        }
     }
 }
 


### PR DESCRIPTION
## What

Bump apache.commons to 3.18.0

## How to review

1. Code Review