### PR TITLE
BAU: Bump apache.commons to 3.18.0

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 }
 
 dependencies {
+    // Force commons-lang3 to patched version to fix Dependabot alert
+    testImplementation 'org.apache.commons:commons-lang3:3.18.0'
+
     constraints {
         testImplementation('io.netty:netty-codec-http:[4.1.125.Final,)') {
             because 'CVE-2025-58056 is fixed in io.netty:netty-codec-http:4.1.125.Final and higher'


### PR DESCRIPTION
## What

Add explicit constraint to ensure Sonarqube uses 3.18.0

## How to review

1. Code Review