### PR TITLE
BAU: Fix CVE-2025-48924 in gradle plugins

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -1,3 +1,13 @@
+buildscript {
+    dependencies {
+        constraints {
+            classpath('org.apache.commons:commons-lang3:[3.18.0,)') {
+                because 'CVE-2025-48924 is fixed in org.apache.commons:commons-lang3:3.18.0 and higher'
+            }
+        }
+    }
+}
+
 plugins {
     id 'java'
     id 'maven-publish'
@@ -11,8 +21,6 @@ repositories {
         url 'https://gds.jfrog.io/artifactory/di-allowed-repos'
     }
 }
-
-
 
 dependencies {
 


### PR DESCRIPTION
## What

The previously added constraint did not apply to the plugins so adding a constraint in the root buildScript that applies to the plugins.

## How to review

1. Code Review

## Related PRs

- Approach cribbed from https://github.com/govuk-one-login/authentication-api/pull/6910