### PR TITLE
BAU: Dependabot to run twice a month only on the 1st and 15th of each month

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
   - package-ecosystem: gradle
     directory: "/"
     schedule:
-      interval: daily
-      time: "03:00"
+      interval: "cron"
+      cronjob: "0 3 1,15 * *"
     cooldown:
       default-days: 7
     open-pull-requests-limit: 100
@@ -23,7 +23,8 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
+      interval: "cron"
+      cronjob: "0 3 1,15 * *"
     open-pull-requests-limit: 10
     groups:
       gha-all-dependencies:


### PR DESCRIPTION
## What

Dependabot to run twice a month only on the 1st and 15th of each month

- Reduces the amount of toil given low benefit of daily updates
- Dependabot doesn't support a 'fornightly' frequency so use a cronjob to run on the 1st and 15th of each month
- Has no impact on vulnerability tracking as this is separate

## How to review

1. Code Review

## Related PRs


https://github.com/govuk-one-login/authentication-api/pull/8187
https://github.com/govuk-one-login/authentication-frontend/pull/3311
https://github.com/govuk-one-login/authentication-stubs/pull/679