### PR TITLE
AUT-4808: Add priority identifier to acceptance tests for send otp no…

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/services/ApiInteractionsService.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/services/ApiInteractionsService.java
@@ -83,7 +83,8 @@ public class ApiInteractionsService {
             {
                 "notificationType": "VERIFY_PHONE_NUMBER",
                 "email": "%s",
-                "phoneNumber": "%s"
+                "phoneNumber": "%s",
+                "priorityIdentifier": "DEFAULT"
             }
             """
                         .formatted(world.userProfile.getEmail(), world.getNewPhoneNumber());
@@ -215,7 +216,8 @@ public class ApiInteractionsService {
             {
                 "notificationType": "VERIFY_PHONE_NUMBER",
                 "email": "%s",
-                "phoneNumber": "%s"
+                "phoneNumber": "%s",
+                "priorityIdentifier": "DEFAULT"
             }
             """
                         .formatted(world.userProfile.getEmail(), world.getNewPhoneNumber());


### PR DESCRIPTION
This is now required by the api for notification types of verify phone number



## Related PRs

This API PR required the field: https://github.com/govuk-one-login/authentication-api/pull/8230
