### PR TITLE
BAU: Force bouncy castle version for CVE-2026-5598 and CVE-2026-0636

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -4,6 +4,9 @@ buildscript {
             classpath('org.apache.commons:commons-lang3:[3.20.0,)') {
                 because 'CVE-2025-48924 is fixed in org.apache.commons:commons-lang3:3.20.0 and higher'
             }
+            classpath('org.bouncycastle:bcprov-jdk18on:[1.84,)') {
+                because 'CVE-2026-5598 is fixed in org.bouncycastle:bcprov-jdk18on:1.84 and higher'
+            }
         }
     }
 }


### PR DESCRIPTION


## What

Force bouncy castle version for CVE-2026-5598 and CVE-2026-0636

Transitive dependency brought in via sonarcloud plugin

## How to review

1. Code Review
1. Check that sonarcloud tasks are running correctly

