### PR TITLE
BAU: Fix reauth cross-tab tests

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/reauthentication.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/reauthentication.feature
@@ -144,7 +144,7 @@ Feature: Reauthentication of user
     And the user enters their email address for reauth
     And the user enters the correct password
     And the user enters the six digit security code from their phone
-    Then the user is taken to the "There’s a problem with this service" page
+    Then the user is taken to the "Sorry, the page has expired" page
 
 
   @reauth-multiple-rp-tab @AUT-3530
@@ -159,7 +159,7 @@ Feature: Reauthentication of user
     And the user switches back to the second tab
     And the user enters the correct password
     And the user enters the six digit security code from their phone
-    Then the user is taken to the "There’s a problem with this service" page
+    Then the user is taken to the "Sorry, the page has expired" page
 
 
   @reauth-multiple-rp-tab @AUT-3530


### PR DESCRIPTION
## What

The backend now redirects invalidated sessions to /session-ended instead of showing the generic error page. Update the two multi-tab reauth scenarios to expect "Sorry, the page has expired" instead of "There's a problem with this service".

## How to review


1. Code Review


## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
