### PR TITLE
AUT-5324: amc passkeys tests fixes

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/UserLifecycleStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/UserLifecycleStepDef.java
@@ -188,6 +188,8 @@ public class UserLifecycleStepDef {
         world.setOtherUserCredentials(
                 userLifecycleService.buildNewUserCredentialsAndPutToDynamodb(
                         world.getOtherUserProfile(), world.getOtherUserPassword()));
+        passkeyLifecycleService.buildPasskeyAndPutToDynamoDb(
+                world.getOtherUserProfile().getPublicSubjectID());
     }
 
     @And("the user has not yet accepted the latest terms and conditions")

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/passkeys.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/passkeys.feature
@@ -34,6 +34,7 @@ Feature: Passkeys
     Then the user is returned to the service
 
 # Create passkey
+  @EnvironmentWithAMCStubDeployed
   Scenario: Existing user without a passkey can create a passkey successfully
     Given a user with no passkey and SMS MFA exists
     And the user has not yet accepted the latest terms and conditions
@@ -53,6 +54,7 @@ Feature: Passkeys
     When the user agrees to the updated terms and conditions
     Then the user is returned to the service
 
+  @EnvironmentWithAMCStubDeployed
   Scenario: Existing user without a passkey is taken to updated terms and conditions if they click skip when creating a passkey
     Given a user with no passkey and SMS MFA exists
     And the user has not yet accepted the latest terms and conditions
@@ -73,6 +75,7 @@ Feature: Passkeys
     When the user agrees to the updated terms and conditions
     Then the user is returned to the service
 
+  @EnvironmentWithAMCStubDeployed
   Scenario: Existing user without a passkey is taken back to create-passkey if they click back when creating a passkey
     Given a user with no passkey and SMS MFA exists
     And the user has not yet accepted the latest terms and conditions


### PR DESCRIPTION
## What

- Fix `Sms user enters the same incorrect email address (known to One Login) 6 times during reauthentication and gets logged out. Owner of incorrect email is not locked out.` test to have the 'owner of incorrect email' have a passkey. This is to skip showing the "create a passkey" screen entirely
- Create new `@EnvironmentWithAMCStubDeployed` cucumber tag so that we can turn off AMC stub-using passkey tests in staging.

## How to review

1. Code Review

