### PR TITLE
BAU: Set up passkey for migrated user step def

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/UserLifecycleStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/UserLifecycleStepDef.java
@@ -50,6 +50,9 @@ public class UserLifecycleStepDef {
         world.userCredentials =
                 userLifecycleService.createUserCredentials(
                         world.userProfile, world.getUserPassword(), MFAMethodType.AUTH_APP);
+        world.userPasskeys =
+                passkeyLifecycleService.buildPasskeyAndPutToDynamoDb(
+                        world.userProfile.getPublicSubjectID());
     }
 
     @Given("a Migrated User with a Default MFA of SMS")
@@ -59,6 +62,9 @@ public class UserLifecycleStepDef {
         world.userCredentials =
                 userLifecycleService.createUserCredentials(
                         world.userProfile, world.getUserPassword(), MFAMethodType.SMS);
+        world.userPasskeys =
+                passkeyLifecycleService.buildPasskeyAndPutToDynamoDb(
+                        world.userProfile.getPublicSubjectID());
     }
 
     @Given("a Migrated User with a Default MFA of {string}")
@@ -70,6 +76,9 @@ public class UserLifecycleStepDef {
                         world.userProfile,
                         world.getUserPassword(),
                         MFAMethodType.fromString(mfaMethodType));
+        world.userPasskeys =
+                passkeyLifecycleService.buildPasskeyAndPutToDynamoDb(
+                        world.userProfile.getPublicSubjectID());
     }
 
     @Given("a User exists")


### PR DESCRIPTION
## What

We already set up a dummy passkey for the user in the "a user exists" step def, but hadn't done it for these ones. This sets up a passkey in this migrated user cases to ensure the acceptance tests pass.

## How to review

1. Code Review