### PR TITLE
BAU: Dependabot to Ignore Gradle versions >= 9

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     ignore:
       - dependency-name: "org.seleniumhq.selenium:selenium-java"
         versions: [ "> 4.11.0" ]
+      - dependency-name: "gradle"
+        versions: [ "[9.0,)" ]
     groups:
       gradle-most-dependencies:
         patterns:


### PR DESCRIPTION


## What

Dependabot to Ignore Gradle versions >= 9

Upgrading to Gradle 9 needs manual work.  Bumping this dependency is breaking Dependabot PRs

## How to review

1. Code Review

## Related PRs

#876 
