### PR TITLE
AUT-5067: Add test to check new back button behaviour

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/back_button_behaviour.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/back_button_behaviour.feature
@@ -1,0 +1,30 @@
+@UI @PasskeysEnabled
+Feature: Back Button Behaviour
+
+  Scenario: User can navigate to reset-password-check-email and navigate back through each page
+    Given a user with SMS MFA exists
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
+    When the user enters their email address
+    Then the user is taken to the "Enter your password" page
+    When the user clicks the forgotten password link
+    Then the user is taken to the "Check your email" page
+    When the user clicks the Back link
+    Then the user is taken to the "Enter your password" page
+    When the user clicks the Back link
+    Then the user is taken to the "Enter your email" page
+    When the user clicks the Back link
+    Then the user is taken to the "Create your GOV.UK One Login or sign in" page
+
+  Scenario: User can navigate to enter-password and navigate back through each page
+    Given a user with SMS MFA exists
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
+    When the user enters their email address
+    Then the user is taken to the "Enter your password" page
+    When the user clicks the Back link
+    Then the user is taken to the "Enter your email" page
+    When the user clicks the Back link
+    Then the user is taken to the "Create your GOV.UK One Login or sign in" page


### PR DESCRIPTION
## What

- This test checks that when a user goes to reset-password-check-email, they can correctly click back to get back to the start of their journey.

## How to review

1. Code review
2. Run against the changes on this branch https://github.com/govuk-one-login/authentication-frontend/pull/3377

## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/3377
