### PR TITLE
Revert "BAU: Bump org.seleniumhq.selenium:selenium-dependencies-bom from 4.35.0 to 4.43.0"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 junit = "6.0.1"
 cucumber = "7.32.0"
 axe = "3.0"
-selenium = "4.43.0"
+selenium = "4.35.0"
 aws-sdk-v2 = "2.42.27"
 json = "20250517"
 rest-assured = "5.5.6"


### PR DESCRIPTION
Reverts govuk-one-login/authentication-acceptance-tests#875

Locally getting the error:
```
Caused by: org.openqa.selenium.WebDriverException: Unable to obtain Selenium Manager Binary
           at org.openqa.selenium.manager.SeleniumManager.getBinary(SeleniumManager.java:232)
           at org.openqa.selenium.manager.SeleniumManager.getBinaryPaths(SeleniumManager.java:278)
           at org.openqa.selenium.remote.service.DriverFinder.getBinaryPaths(DriverFinder.java:103)
           ... 7 more
        Caused by: org.openqa.selenium.WebDriverException: Linux ARM is not supported by Selenium Manager
        Build info: version: '4.43.0', revision: 'dd0f534'
        System info: os.name: 'Linux', os.arch: 'aarch64', os.version: '6.12.5-linuxkit', java.version: '17.0.18-ea'
        Driver info: driver.version: Driver
           at org.openqa.selenium.manager.SeleniumManager.getBinary(SeleniumManager.java:208)
           ... 9 more
```