### PR TITLE
AUT-4988: Handle passkey created screen

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/passkeys.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/passkeys.feature
@@ -50,6 +50,8 @@ Feature: Passkeys
     When the user clicks the continue button
     Then the user is taken to the AMC stub page passkey create page
     When the user clicks the continue button
+    Then the user is taken to the "You’ve set up a passkey" page
+    When the user clicks the continue button
     Then the user is taken to the "We’ve updated our terms of use" page
     When the user agrees to the updated terms and conditions
     Then the user is returned to the service


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

The "passkey created" screen/page added under https://github.com/govuk-one-login/authentication-frontend/pull/3339 was previously not handled here.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Run against an env (e.g. `./rundocker.sh dev-ui`)
1. Ensure expected tests pass
-->

1. Code Review

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

Frontend PR: https://github.com/govuk-one-login/authentication-frontend/pull/3339