### PR TITLE
BAU: Bump opentelemetry-api to 1.62.0 and netty to 4.2.13.Final to fix CVE-2026-45292 and CVE-2026-42587

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -51,8 +51,14 @@ dependencies {
         testImplementation('org.apache.commons:commons-lang3:[3.20.0,)') {
             because 'CVE-2025-48924 is fixed in org.apache.commons:commons-lang3:3.20.0 and higher'
         }
-        testImplementation('io.netty:netty-codec-http:[4.2.7.Final,)') {
-            because 'CVE-2025-58056 is fixed in io.netty:netty-codec-http:4.2.7.Final and higher'
+        testImplementation('io.netty:netty-codec-http:[4.2.13.Final,)') {
+            because 'CVE-2026-42587 is fixed in io.netty:netty-codec-http:4.2.13.Final and higher'
+        }
+        testImplementation('io.netty:netty-codec-http2:[4.2.13.Final,)') {
+            because 'CVE-2026-42587 is fixed in io.netty:netty-codec-http2:4.2.13.Final and higher'
+        }
+        testImplementation('io.opentelemetry:opentelemetry-api:[1.62.0,)') {
+            because 'CVE-2026-45292 is fixed in io.opentelemetry:opentelemetry-api:1.62.0 and higher'
         }
         testImplementation('org.apache.logging.log4j:log4j-core:[2.25.3,3)') {
             because 'CVE-2025-68161 is fixed in org.apache.logging.log4j:log4j-core:2.25.3 and higher'


### PR DESCRIPTION
## Summary

Adds/updates dependency constraints to fix two open Dependabot alerts:

- **CVE-2026-45292** (Medium, CVSS 5.3): OpenTelemetry Java SDK unbounded memory allocation in W3C Baggage propagation. Fixed in opentelemetry-api 1.62.0.
- **CVE-2026-42587**: Netty HttpContentDecompressor maxAllocation bypass for br/zstd/snappy leading to decompression bomb DoS. Fixed in netty-codec-http/netty-codec-http2 4.2.13.Final.

## Changes

- Added constraint: `io.opentelemetry:opentelemetry-api:[1.62.0,)`
- Added constraint: `io.netty:netty-codec-http2:[4.2.13.Final,)`
- Bumped existing constraint: `io.netty:netty-codec-http` from 4.2.7.Final to 4.2.13.Final
- Removed stale CVE-2025-58056 reference (superseded by CVE-2026-42587)

## Testing

- `./gradlew compileTestJava` passes
- Dependency tree confirms opentelemetry-api resolves to 1.62.0 and netty resolves to >= 4.2.13.Final