### PR TITLE
BAU: Bump opentelemetry-api to 1.62.0 and netty to 4.2.13.Final to fix CVE-2026-45292 and CVE-2026-42587

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -51,8 +51,14 @@ dependencies {
         testImplementation('org.apache.commons:commons-lang3:[3.20.0,)') {
             because 'CVE-2025-48924 is fixed in org.apache.commons:commons-lang3:3.20.0 and higher'
         }
-        testImplementation('io.netty:netty-codec-http:[4.2.7.Final,)') {
-            because 'CVE-2025-58056 is fixed in io.netty:netty-codec-http:4.2.7.Final and higher'
+        testImplementation('io.netty:netty-codec-http:[4.2.13.Final,)') {
+            because 'CVE-2026-42587 is fixed in io.netty:netty-codec-http:4.2.13.Final and higher'
+        }
+        testImplementation('io.netty:netty-codec-http2:[4.2.13.Final,)') {
+            because 'CVE-2026-42587 is fixed in io.netty:netty-codec-http2:4.2.13.Final and higher'
+        }
+        testImplementation('io.opentelemetry:opentelemetry-api:[1.62.0,)') {
+            because 'CVE-2026-45292 is fixed in io.opentelemetry:opentelemetry-api:1.62.0 and higher'
         }
         testImplementation('org.apache.logging.log4j:log4j-core:[2.25.3,3)') {
             because 'CVE-2025-68161 is fixed in org.apache.logging.log4j:log4j-core:2.25.3 and higher'


### PR DESCRIPTION
## What

- Adds dependency constraint for `io.opentelemetry:opentelemetry-api:[1.62.0,)` to fix CVE-2026-45292 (unbounded memory allocation in W3C Baggage propagation)
- Adds dependency constraint for `io.netty:netty-codec-http2:[4.2.13.Final,)` to fix CVE-2026-42587 (decompression bomb DoS via maxAllocation bypass in brotli/zstd/snappy)
- Bumps existing `io.netty:netty-codec-http` constraint from 4.2.7.Final to 4.2.13.Final (same fix)
- Removes stale CVE-2025-58056 reference superseded by CVE-2026-42587

## How to review

1. Code Review