### PR TITLE
BAU: Bump netty to 4.2.13.Final to fix CVE-2026-42587

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -51,8 +51,11 @@ dependencies {
         testImplementation('org.apache.commons:commons-lang3:[3.20.0,)') {
             because 'CVE-2025-48924 is fixed in org.apache.commons:commons-lang3:3.20.0 and higher'
         }
-        testImplementation('io.netty:netty-codec-http:[4.2.7.Final,)') {
-            because 'CVE-2025-58056 is fixed in io.netty:netty-codec-http:4.2.7.Final and higher'
+        testImplementation('io.netty:netty-codec-http:[4.2.13.Final,)') {
+            because 'CVE-2026-42587 is fixed in io.netty:netty-codec-http:4.2.13.Final and higher'
+        }
+        testImplementation('io.netty:netty-codec-http2:[4.2.13.Final,)') {
+            because 'CVE-2026-42587 is fixed in io.netty:netty-codec-http2:4.2.13.Final and higher'
         }
         testImplementation('org.apache.logging.log4j:log4j-core:[2.25.3,3)') {
             because 'CVE-2025-68161 is fixed in org.apache.logging.log4j:log4j-core:2.25.3 and higher'


### PR DESCRIPTION
## What

- Bumps `io.netty:netty-codec-http` and `io.netty:netty-codec-http2` dependency constraints to 4.2.13.Final to resolve [CVE-2026-42587](https://github.com/advisories/GHSA-f6hv-jmp6-3vwv) (HttpContentDecompressor maxAllocation bypass for br/zstd/snappy leading to decompression bomb DoS)
- Supersedes the previous `netty-codec-http` constraint at 4.2.7.Final (CVE-2025-58056), which is also covered by 4.2.13.Final

## How to review

1. Code Review