### PR TITLE
BAU: Bump opentelemetry-api to 1.62.0 to fix CVE-2026-45292

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -60,6 +60,9 @@ dependencies {
         testImplementation('com.fasterxml.jackson.core:jackson-core:[2.21.1,)') {
             because 'CVE jackson-core Number Length Constraint Bypass in Async Parser (CVSS 8.7) fixed in 2.21.1'
         }
+        testImplementation('io.opentelemetry:opentelemetry-api:[1.62.0,)') {
+            because 'CVE-2026-45292 is fixed in io.opentelemetry:opentelemetry-api:1.62.0 and higher'
+        }
     }
 }
 


### PR DESCRIPTION
## What

- Adds a dependency constraint for `io.opentelemetry:opentelemetry-api` to 1.62.0+ to resolve [CVE-2026-45292](https://github.com/advisories/GHSA-rcgg-9c38-7xpx) (Unbounded Memory Allocation in W3C Baggage Propagation)

## How to review

1. Code Review