### PR TITLE
BAU: Bump netty-codec-http2 to 4.1.133.Final to fix CVE-2026-42587

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -54,6 +54,9 @@ dependencies {
         testImplementation('io.netty:netty-codec-http:[4.2.7.Final,)') {
             because 'CVE-2025-58056 is fixed in io.netty:netty-codec-http:4.2.7.Final and higher'
         }
+        testImplementation('io.netty:netty-codec-http2:[4.1.133.Final,)') {
+            because 'CVE-2026-42587 is fixed in io.netty:netty-codec-http2:4.1.133.Final and higher'
+        }
         testImplementation('org.apache.logging.log4j:log4j-core:[2.25.3,3)') {
             because 'CVE-2025-68161 is fixed in org.apache.logging.log4j:log4j-core:2.25.3 and higher'
         }


### PR DESCRIPTION
## What

- Adds a dependency constraint to force `io.netty:netty-codec-http2` to >= 4.1.133.Final, resolving [CVE-2026-42587](https://github.com/advisories/GHSA-f6hv-jmp6-3vwv) (HttpContentDecompressor maxAllocation bypass for br/zstd/snappy leading to decompression bomb DoS)

## How to review

1. Code Review