### PR TITLE
BAU: Constrain opentelemetry-api to 1.62.0 to fix CVE-2026-45292

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -7,6 +7,9 @@ buildscript {
             classpath('org.bouncycastle:bcprov-jdk18on:[1.84,)') {
                 because 'CVE-2026-5598 is fixed in org.bouncycastle:bcprov-jdk18on:1.84 and higher'
             }
+            classpath('io.opentelemetry:opentelemetry-api:[1.62.0,)') {
+                because 'CVE-2026-45292 is fixed in io.opentelemetry:opentelemetry-api:1.62.0 and higher'
+            }
         }
     }
 }
@@ -59,6 +62,9 @@ dependencies {
         }
         testImplementation('com.fasterxml.jackson.core:jackson-core:[2.21.1,)') {
             because 'CVE jackson-core Number Length Constraint Bypass in Async Parser (CVSS 8.7) fixed in 2.21.1'
+        }
+        testImplementation('io.opentelemetry:opentelemetry-api:[1.62.0,)') {
+            because 'CVE-2026-45292 is fixed in io.opentelemetry:opentelemetry-api:1.62.0 and higher'
         }
     }
 }


### PR DESCRIPTION
## What

- Constrains io.opentelemetry:opentelemetry-api to >=1.62.0 to fix CVE-2026-45292 (unbounded memory allocation in W3C Baggage propagation). This is a transitive dependency brought in via the AWS SDK BOM.

## How to review

1. Code Review