### PR TITLE
BAU: Constrain netty-codec-http2 to 4.1.133.Final to fix CVE-2026-42587

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -7,6 +7,9 @@ buildscript {
             classpath('org.bouncycastle:bcprov-jdk18on:[1.84,)') {
                 because 'CVE-2026-5598 is fixed in org.bouncycastle:bcprov-jdk18on:1.84 and higher'
             }
+            classpath('io.netty:netty-codec-http2:[4.1.133.Final,)') {
+                because 'CVE-2026-42587 is fixed in io.netty:netty-codec-http2:4.1.133.Final and higher'
+            }
         }
     }
 }
@@ -59,6 +62,9 @@ dependencies {
         }
         testImplementation('com.fasterxml.jackson.core:jackson-core:[2.21.1,)') {
             because 'CVE jackson-core Number Length Constraint Bypass in Async Parser (CVSS 8.7) fixed in 2.21.1'
+        }
+        testImplementation('io.netty:netty-codec-http2:[4.1.133.Final,)') {
+            because 'CVE-2026-42587 is fixed in io.netty:netty-codec-http2:4.1.133.Final and higher'
         }
     }
 }


### PR DESCRIPTION
## What

- Constrains io.netty:netty-codec-http2 to >=4.1.133.Final to fix CVE-2026-42587 (HTTP/2 CONTINUATION flood causing unbounded CPU consumption). This is a transitive dependency.

## How to review

1. Code Review