### PR TITLE
Aut 4989/account exists with passkey

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/UserLifecycleStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/UserLifecycleStepDef.java
@@ -83,7 +83,8 @@ public class UserLifecycleStepDef {
 
     @Given("a User exists")
     @Given("a user exists")
-    public void aUserExists() {
+    @Given("a user exists with a passkey")
+    public void aUserExistsWithAPasskey() {
         aUserDoesNotYetExist();
         userLifecycleService.putUserProfileToDynamodb(world.userProfile);
         world.userCredentials =
@@ -111,8 +112,10 @@ public class UserLifecycleStepDef {
 
     @Given("a user with {string} MFA exists")
     @Given("a user with {mfaMethod} MFA exists")
-    public void aUserExists(String mfaMethod) {
-        aUserExists();
+    @Given("a user with {string} MFA and a passkey exists")
+    @Given("a user with {mfaMethod} MFA and a passkey exists")
+    public void aUserExistsWithAPasskey(String mfaMethod) {
+        aUserExistsWithAPasskey();
         switch (mfaMethod) {
             case "no":
                 break;
@@ -153,7 +156,7 @@ public class UserLifecycleStepDef {
 
     @Given("a user with unique international SMS MFA exists")
     public void aUserWithUniqueInternationalSmsMfaExists() {
-        aUserExists();
+        aUserExistsWithAPasskey();
         userLifecycleService.updateUserMfaSmsWithUniqueInternationalNumber(world.userProfile);
     }
 

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/existing_user_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/existing_user_journey.feature
@@ -71,3 +71,14 @@ Feature: Login Journey
     # Second (silent) sign in
     When the user comes from the stub relying party with option authenticated-2
     Then the user is returned to the service
+
+  @PasskeyUsageEnabled
+  Scenario: Existing user with a passkey tries to create an account with the same email address
+    Given a user exists with a passkey
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects create an account
+    Then the user is taken to the "Enter your email address" page
+    When the user enters their email address
+    Then the user is taken to the "You have a GOV.UK One Login" page
+    When the user clicks the continue button
+    Then the user is taken to the "Sign in with your face, fingerprint or passcode" page


### PR DESCRIPTION
## What

Adds a test (feature flagged off in all envs currently) for account exists with passkey behaviour.

This is behind a new feature flag which denotes whether or not the environment has the "support passkey usage" feature flag on or off. This determines whether we prompt users to sign in with a passkey or not.

## How to review


1. Code Review

## Related PRs

PRs that implement this behaviour on the frontend have been merged already.

Since this new test is feature flagged off in all envs, merging this will have no impact until the feature flag is turned on in dev.
