### PR TITLE
AUT-5420/support passkey usage

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/CreatePasskeysPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/CreatePasskeysPage.java
@@ -22,4 +22,14 @@ public class CreatePasskeysPage extends BasePage {
     public void clickSkipButton() {
         Driver.get().findElement(skipButton).click();
     }
+
+    public void dismissIfPresent() {
+        // Prevents a race condition after MFA code submission. In non-MFA flows this is a no-op.
+        new WebDriverWait(Driver.get(), DEFAULT_PAGE_LOAD_WAIT_TIME)
+                .until(ExpectedConditions.not(ExpectedConditions.urlContains("/enter-code")));
+        waitForReadyStateComplete();
+        if (Driver.get().getCurrentUrl().contains(PATH)) {
+            clickSkipButton();
+        }
+    }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/services/DynamoDbService.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/services/DynamoDbService.java
@@ -4,6 +4,7 @@ import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import uk.gov.di.test.entity.Passkey;
 import uk.gov.di.test.entity.SmsInternationalNumberSendLimit;
@@ -126,6 +127,15 @@ public class DynamoDbService {
 
     public void putPasskey(Passkey passkey) {
         authenticatorPasskeyTable.putItem(passkey);
+    }
+
+    public List<Passkey> queryPasskeysByPublicSubjectId(String publicSubjectId) {
+        Key key = Key.builder().partitionValue(publicSubjectId).build();
+        return authenticatorPasskeyTable
+                .query(r -> r.queryConditional(QueryConditional.keyEqualTo(key)))
+                .items()
+                .stream()
+                .toList();
     }
 
     public void deletePasskeys(List<Passkey> passkeys) {

--- a/acceptance-tests/src/test/java/uk/gov/di/test/services/PasskeyLifecycleService.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/services/PasskeyLifecycleService.java
@@ -39,8 +39,11 @@ public class PasskeyLifecycleService {
         return List.of(passkey);
     }
 
-    public void deletePasskeysForUser(List<Passkey> passkeys) {
-        DYNAMO_DB_SERVICE.deletePasskeys(passkeys);
+    public void deleteAllPasskeysForUser(String publicSubjectId) {
+        List<Passkey> passkeys = DYNAMO_DB_SERVICE.queryPasskeysByPublicSubjectId(publicSubjectId);
+        if (!passkeys.isEmpty()) {
+            DYNAMO_DB_SERVICE.deletePasskeys(passkeys);
+        }
     }
 
     public static String buildSortKey(String passkeyId) {

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CrossPageFlows.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CrossPageFlows.java
@@ -5,6 +5,7 @@ import uk.gov.di.test.pages.CheckYourEmailPage;
 import uk.gov.di.test.pages.CheckYourPhonePage;
 import uk.gov.di.test.pages.ChooseHowToGetSecurityCodesPage;
 import uk.gov.di.test.pages.CreateOrSignInPage;
+import uk.gov.di.test.pages.CreatePasskeysPage;
 import uk.gov.di.test.pages.CreateYourPasswordPage;
 import uk.gov.di.test.pages.EnterThe6DigitSecurityCodeShownInYourAuthenticatorAppPage;
 import uk.gov.di.test.pages.EnterYourEmailAddressToSignInPage;
@@ -89,7 +90,7 @@ public class CrossPageFlows extends BasePage {
         }
     }
 
-    private void enterMfaCodeAndContinue() {
+    private void enterMfaCodeAndContinueDismissingPasskeys() {
         switch (world.getMfaType()) {
             case SMS:
                 waitForPageLoad("Check your phone");
@@ -104,6 +105,11 @@ public class CrossPageFlows extends BasePage {
             default:
                 throw new RuntimeException("Invalid MFA type: " + world.getMfaType());
         }
+        dismissPasskeyRegistrationPageIfPresent();
+    }
+
+    private void dismissPasskeyRegistrationPageIfPresent() {
+        new CreatePasskeysPage().dismissIfPresent();
     }
 
     public void successfulSignIn() {
@@ -116,7 +122,7 @@ public class CrossPageFlows extends BasePage {
         enterYourEmailAddressToSignInPage.enterEmailAddressAndContinue(world.getUserEmailAddress());
         enterYourPasswordPage.waitForPage();
         enterYourPasswordPage.enterPasswordAndContinue(world.getUserPassword());
-        enterMfaCodeAndContinue();
+        enterMfaCodeAndContinueDismissingPasskeys();
         stubUserInfoPage.waitForReturnToTheService();
     }
 
@@ -158,7 +164,7 @@ public class CrossPageFlows extends BasePage {
                 world.getUserEmailAddress());
         enterYourPasswordPage.waitForPage();
         enterYourPasswordPage.enterCorrectPasswordAndContinue();
-        enterMfaCodeAndContinue();
+        enterMfaCodeAndContinueDismissingPasskeys();
         stubUserInfoPage.waitForReturnToTheService();
     }
 
@@ -245,6 +251,7 @@ public class CrossPageFlows extends BasePage {
         checkYourPhonePage.enterCorrectPhoneCodeAndContinue();
         waitForPageLoad("You’ve created your GOV.UK One Login");
         findAndClickContinue();
+        dismissPasskeyRegistrationPageIfPresent();
         stubUserInfoPage.waitForReturnToTheService();
         stubUserInfoPage.logoutOfAccount();
     }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/Hooks.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/Hooks.java
@@ -75,6 +75,8 @@ public class Hooks extends BasePage {
             LOG.info(
                     "After Account management API hook: Deleting user profile with email {}",
                     world.userProfile.getEmail());
+            passkeyLifecycleService.deleteAllPasskeysForUser(
+                    world.userProfile.getPublicSubjectID());
             userLifecycleService.deleteUserProfileFromDynamodb(world.userProfile);
         }
         if (world.userCredentials != null) {
@@ -82,12 +84,6 @@ public class Hooks extends BasePage {
                     "After API hook: Deleting user credentials with email {}",
                     world.userCredentials.getEmail());
             userLifecycleService.deleteUserCredentialsFromDynamodb(world.userCredentials);
-        }
-        if (world.userPasskeys != null && !world.userPasskeys.isEmpty()) {
-            LOG.info(
-                    "After API hook: Deleting user passkeys with email {}",
-                    world.userCredentials.getEmail());
-            passkeyLifecycleService.deletePasskeysForUser(world.userPasskeys);
         }
         Driver.get().manage().deleteAllCookies();
         Driver.closeDriver();

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/PasskeysStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/PasskeysStepDef.java
@@ -1,5 +1,6 @@
 package uk.gov.di.test.step_definitions;
 
+import io.cucumber.java.en.And;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import uk.gov.di.test.pages.BasePage;
@@ -21,5 +22,10 @@ public class PasskeysStepDef extends BasePage {
     @Then("the user is taken to the AMC stub page passkey create page")
     public void theUserIsTakenToTheAMCStubPagePasskeyCreatePage() {
         waitForThisText("AMC stub (passkey create)");
+    }
+
+    @And("the user dismisses the passkey registration page if present")
+    public void dismissPasskeyRegistrationPageIfPresent() {
+        createPasskeysPage.dismissIfPresent();
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/UserLifecycleStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/UserLifecycleStepDef.java
@@ -50,9 +50,6 @@ public class UserLifecycleStepDef {
         world.userCredentials =
                 userLifecycleService.createUserCredentials(
                         world.userProfile, world.getUserPassword(), MFAMethodType.AUTH_APP);
-        world.userPasskeys =
-                passkeyLifecycleService.buildPasskeyAndPutToDynamoDb(
-                        world.userProfile.getPublicSubjectID());
     }
 
     @Given("a Migrated User with a Default MFA of SMS")
@@ -62,9 +59,6 @@ public class UserLifecycleStepDef {
         world.userCredentials =
                 userLifecycleService.createUserCredentials(
                         world.userProfile, world.getUserPassword(), MFAMethodType.SMS);
-        world.userPasskeys =
-                passkeyLifecycleService.buildPasskeyAndPutToDynamoDb(
-                        world.userProfile.getPublicSubjectID());
     }
 
     @Given("a Migrated User with a Default MFA of {string}")
@@ -76,28 +70,11 @@ public class UserLifecycleStepDef {
                         world.userProfile,
                         world.getUserPassword(),
                         MFAMethodType.fromString(mfaMethodType));
-        world.userPasskeys =
-                passkeyLifecycleService.buildPasskeyAndPutToDynamoDb(
-                        world.userProfile.getPublicSubjectID());
     }
 
     @Given("a User exists")
     @Given("a user exists")
-    @Given("a user exists with a passkey")
-    public void aUserExistsWithAPasskey() {
-        aUserDoesNotYetExist();
-        userLifecycleService.putUserProfileToDynamodb(world.userProfile);
-        world.userCredentials =
-                userLifecycleService.buildNewUserCredentialsAndPutToDynamodb(
-                        world.userProfile, world.getUserPassword());
-        world.userPasskeys =
-                passkeyLifecycleService.buildPasskeyAndPutToDynamoDb(
-                        world.userProfile.getPublicSubjectID());
-    }
-
-    @Given("a User exists with no passkey")
-    @Given("a user exists with no passkey")
-    public void aUserExistsWithNoPasskey() {
+    public void aUserExists() {
         aUserDoesNotYetExist();
         userLifecycleService.putUserProfileToDynamodb(world.userProfile);
         world.userCredentials =
@@ -112,10 +89,10 @@ public class UserLifecycleStepDef {
 
     @Given("a user with {string} MFA exists")
     @Given("a user with {mfaMethod} MFA exists")
-    @Given("a user with {string} MFA and a passkey exists")
-    @Given("a user with {mfaMethod} MFA and a passkey exists")
-    public void aUserExistsWithAPasskey(String mfaMethod) {
-        aUserExistsWithAPasskey();
+    @Given("a user with no passkey and {string} MFA exists")
+    @Given("a user with no passkey and {mfaMethod} MFA exists")
+    public void aUserExists(String mfaMethod) {
+        aUserExists();
         switch (mfaMethod) {
             case "no":
                 break;
@@ -133,30 +110,16 @@ public class UserLifecycleStepDef {
         }
     }
 
-    @Given("a user with no passkey and {string} MFA exists")
-    @Given("a user with no passkey and {mfaMethod} MFA exists")
-    public void aUserExistsWithNoPasskeyAndMfaMethod(String mfaMethod) {
-        aUserExistsWithNoPasskey();
-        switch (mfaMethod) {
-            case "no":
-                break;
-            case "SMS":
-                userLifecycleService.updateUserMfaSms(world.userProfile);
-                break;
-            case "App":
-                world.userProfile.setPhoneNumber(null);
-                world.userProfile.setPhoneNumberVerified(false);
-                userLifecycleService.putUserProfileToDynamodb(world.userProfile);
-                userLifecycleService.updateUserMfaApp(world.userCredentials);
-                break;
-            default:
-                throw new RuntimeException("Invalid MFA Method");
-        }
+    @Given("a user exists with a passkey")
+    public void aUserExistsWithAPasskey() {
+        aUserExists();
+        passkeyLifecycleService.buildPasskeyAndPutToDynamoDb(
+                world.userProfile.getPublicSubjectID());
     }
 
     @Given("a user with unique international SMS MFA exists")
     public void aUserWithUniqueInternationalSmsMfaExists() {
-        aUserExistsWithAPasskey();
+        aUserExists();
         userLifecycleService.updateUserMfaSmsWithUniqueInternationalNumber(world.userProfile);
     }
 
@@ -200,8 +163,6 @@ public class UserLifecycleStepDef {
         world.setOtherUserCredentials(
                 userLifecycleService.buildNewUserCredentialsAndPutToDynamodb(
                         world.getOtherUserProfile(), world.getOtherUserPassword()));
-        passkeyLifecycleService.buildPasskeyAndPutToDynamoDb(
-                world.getOtherUserProfile().getPublicSubjectID());
     }
 
     @And("the user has not yet accepted the latest terms and conditions")
@@ -223,17 +184,14 @@ public class UserLifecycleStepDef {
         if (world.userProfile != null) {
             System.out.printf(
                     "Deleting user profile with email %s%n", world.userProfile.getEmail());
+            passkeyLifecycleService.deleteAllPasskeysForUser(
+                    world.userProfile.getPublicSubjectID());
             userLifecycleService.deleteUserProfileFromDynamodb(world.userProfile);
         }
         if (world.userCredentials != null) {
             System.out.printf(
                     "Deleting user credentials with email %s%n", world.userCredentials.getEmail());
             userLifecycleService.deleteUserCredentialsFromDynamodb(world.userCredentials);
-        }
-        if (world.userPasskeys != null && !world.userPasskeys.isEmpty()) {
-            System.out.printf(
-                    "Deleting passkeys for user with email %s%n", world.userProfile.getEmail());
-            passkeyLifecycleService.deletePasskeysForUser(world.userPasskeys);
         }
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/World.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/World.java
@@ -1,14 +1,12 @@
 package uk.gov.di.test.step_definitions;
 
 import io.restassured.response.Response;
-import uk.gov.di.test.entity.Passkey;
 import uk.gov.di.test.entity.UserCredentials;
 import uk.gov.di.test.entity.UserInterventions;
 import uk.gov.di.test.entity.UserProfile;
 import uk.gov.di.test.services.UserLifecycleService;
 import uk.gov.di.test.utils.MFAType;
 
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -24,7 +22,6 @@ public class World {
     public UserLifecycleService userLifecycleService;
     public UserCredentials userCredentials;
     public UserInterventions userInterventions;
-    public List<Passkey> userPasskeys;
     private String userPassword;
 
     private UserProfile otherUserProfile;

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/login/using-back-up-mfa.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/login/using-back-up-mfa.feature
@@ -156,6 +156,7 @@ Feature: Login Using Back Up MFA
     When the user clicks the continue button
     Then the user is taken to the "Check your phone" page
     When the user enters the six digit security code from their phone
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
   Scenario: User requests too many OTPs when authenticating with a Backup SMS MFA
@@ -228,6 +229,7 @@ Feature: Login Using Back Up MFA
     When the user clicks the continue button
     Then the user is taken to the "Check your phone" page
     When the user enters the six digit security code from their phone
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
   Scenario: A User loses access to their Default Auth App and requests too many OTPs when authenticating with a Backup SMS MFA and lockout
@@ -430,6 +432,7 @@ Feature: Login Using Back Up MFA
     And the user enters the security code from backup MFA auth app
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
   Scenario: User resets password using a Backup SMS MFA
@@ -458,6 +461,7 @@ Feature: Login Using Back Up MFA
     When the user enters the six digit security code from their phone
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
   Scenario: User with Auth App Default MFA requests too many OTPs when resetting their password with a Backup SMS MFA and lockout
@@ -672,6 +676,7 @@ Feature: Login Using Back Up MFA
     When the user enters their email address
     Then the user is taken to the "Enter your password" page
     When the user enters their password
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     When the user comes from the stub relying party with options: [2fa-on,authenticated-2] and is taken to the "Enter a security code to continue" page
     Then the user is taken to the "Enter a security code to continue" page
@@ -682,6 +687,7 @@ Feature: Login Using Back Up MFA
     When the user clicks the continue button
     Then the user is taken to the "Enter a security code to continue" page
     When the user enters the six digit security code from their phone
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
   Scenario: User with Auth App as Default MFA and SMS as backup MFA switches MFA in uplift journey
@@ -698,6 +704,7 @@ Feature: Login Using Back Up MFA
     When the user enters their email address
     Then the user is taken to the "Enter your password" page
     When the user enters their password
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     When the user comes from the stub relying party with options: [2fa-on,authenticated-2] and is taken to the "Enter a security code to continue" page
     Then the user is taken to the "Enter a security code to continue" page
@@ -707,6 +714,7 @@ Feature: Login Using Back Up MFA
     When the user clicks the continue button
     Then the user is taken to the "Enter a security code to continue" page
     When the user enters the six digit security code from their phone
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
   Scenario: Sms user successfully reauthenticate with backup phone number
@@ -812,6 +820,7 @@ Feature: Login Using Back Up MFA
     When the user enters their password
     Then the user is taken to the "Check your phone" page
     When the user enters the six digit security code from their phone
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     And the user info JSON is extracted from the stub page
     And the "phone_number_verified" is true
@@ -830,6 +839,7 @@ Feature: Login Using Back Up MFA
     When the user enters their password
     Then the user is taken to the "Check your phone" page
     When the user enters the six digit security code from their phone
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     And the user info JSON is extracted from the stub page
     And the "phone_number_verified" is true
@@ -850,6 +860,7 @@ Feature: Login Using Back Up MFA
     When the user enters their password
     Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
     When the user enters the six digit code for "App"
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     And the user info JSON is extracted from the stub page
     And the "phone_number_verified" is false
@@ -864,6 +875,7 @@ Feature: Login Using Back Up MFA
     When the user enters their password
     Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
     When the user enters the six digit code for "App"
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     And the user info JSON is extracted from the stub page
     And the "phone_number_verified" is false
@@ -879,6 +891,7 @@ Feature: Login Using Back Up MFA
     When the user enters their password
     Then the user is taken to the "Check your phone" page
     When the user enters the six digit security code from their phone
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     And the user info JSON is extracted from the stub page
     And the "phone_number_verified" is true

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/mfa-reset/migrated-users/mfa-reset-migrated.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/mfa-reset/migrated-users/mfa-reset-migrated.feature
@@ -32,6 +32,7 @@ And the user enters their mobile phone number
 And the user enters the six digit security code from their phone
 Then the user is taken to the "You’ve changed how you get security codes" page
 When the user clicks the continue button
+And the user dismisses the passkey registration page if present
 Then the user is returned to the service
 And the User only has a default MFA of "SMS" and remains migrated
 
@@ -59,5 +60,6 @@ When the user adds the secret key on the screen to their auth app
 And the user enters the security code from the auth app
 Then the user is taken to the "You’ve changed how you get security codes" page
 When the user clicks the continue button
+And the user dismisses the passkey registration page if present
 Then the user is returned to the service
 And the User only has a default MFA of "AUTH_APP" and remains migrated

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/account_interventions.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/account_interventions.feature
@@ -323,6 +323,7 @@ Feature: Account interventions
 #    Then the user is taken to the "Reset your password" page
 #    The test needs to stop here in Build, due to there being static data in the AIS stub the reset pw flag is not removed and so the correct path is not followed
 #    When the user enters valid new password and correctly retypes it
+#    And the user dismisses the passkey registration page if present
 #    Then the user is returned to the service
 #    And the user clicks logout
 
@@ -343,6 +344,7 @@ Feature: Account interventions
     When the user enters the six digit security code from their email
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
   Scenario: Auth app user with a password reset intervention on their account is able to use the I have forgotten my password link
@@ -360,6 +362,7 @@ Feature: Account interventions
     When the user enters the security code from the auth app
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
   Scenario: Sms user is forced to reset their password when they have a password reset intervention on their account and their existing password is on top 100k password list
@@ -378,6 +381,7 @@ Feature: Account interventions
     When the user enters the six digit security code from their phone
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
   Scenario: Auth app user with outdated terms and conditions cannot log in when they have a password reset intervention on their account
@@ -400,6 +404,7 @@ Feature: Account interventions
     When the user enters the six digit security code from their email
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
   @old-mfa-without-ipv
@@ -423,6 +428,7 @@ Feature: Account interventions
     When the user enters the six digit security code from their email
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
   @under-development @old-mfa-without-ipv
@@ -469,4 +475,5 @@ Feature: Account interventions
     When the user enters their password
     Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
     When the user enters the security code from the auth app
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/account_recovery.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/account_recovery.feature
@@ -22,6 +22,7 @@ Feature: Account recovery
     And the user enters the security code from the auth app
     Then the user is taken to the "You’ve changed how you get security codes" page
     And confirmation that the user will get security codes via "auth app" is displayed
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     And the user logs out
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -32,6 +33,7 @@ Feature: Account recovery
     When the user enters their password
     Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
     When the user enters the security code from the auth app
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
   @under-development
@@ -55,6 +57,7 @@ Feature: Account recovery
     And the user enters the security code from the auth app
     Then the user is taken to the "You’ve changed how you get security codes" page
     And the user clicks the continue button
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
     And the user selects sign in
@@ -64,6 +67,7 @@ Feature: Account recovery
     When the user enters their password
     Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
     When the user enters the security code from the auth app
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
   @old-mfa-without-ipv
@@ -88,6 +92,7 @@ Feature: Account recovery
     When the user enters the six digit security code from their phone
     Then the user is taken to the "You’ve changed how you get security codes" page
     And confirmation that the user will get security codes via "text message" is displayed
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     And the user logs out
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -98,6 +103,7 @@ Feature: Account recovery
     When the user enters their password
     Then the user is taken to the "Check your phone" page
     When the user enters the six digit security code from their phone
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
   @under-development
@@ -122,6 +128,7 @@ Feature: Account recovery
     When the user enters the six digit security code from their phone
     Then the user is taken to the "You’ve changed how you get security codes" page
     And the user clicks the continue button
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
     When the user selects sign in
@@ -131,4 +138,5 @@ Feature: Account recovery
     When the user enters their password
     Then the user is taken to the "Check your phone" page
     When the user enters the six digit security code from their phone
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/auth_app_2fa_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/auth_app_2fa_journey.feature
@@ -2,7 +2,6 @@
 Feature: Authentication App Journeys
   New user creates an account and logs in using an auth app
 
-  @SignInWithoutPasskeys
   Scenario: User successfully registers with auth app 2FA and login with 2fa-on
     Given a user does not yet exist
     When the user comes from the stub relying party with option 2fa-off and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -32,41 +31,7 @@ Feature: Authentication App Journeys
     When the user enters their password
     Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
     When the user enters the security code from the auth app
-    Then the user is returned to the service
-
-# This test duplicates the flow of the test above for envs where the passkeys feature flag is turned on
-  @PasskeysEnabled
-  Scenario: User successfully registers with auth app 2FA and login with 2fa-on
-    Given a user does not yet exist
-    When the user comes from the stub relying party with option 2fa-off and is taken to the "Create your GOV.UK One Login or sign in" page
-    When the user selects create an account
-    Then the user is taken to the "Enter your email" page
-    When the user enters their email address
-    Then the user is taken to the "Check your email" page
-    When the user enters the six digit security code from their email
-    Then the user is taken to the "Create your password" page
-    When the user creates a password
-    Then the user is taken to the "Choose how to get security codes" page
-    When the user chooses auth app to get security codes
-    Then the user is taken to the "Set up an authenticator app" page
-    When the user adds the secret key on the screen to their auth app
-    And the user enters the security code from the auth app
-    Then the user is not shown any error messages
-    And the user is taken to the "You’ve created your GOV.UK One Login" page
-    When the user clicks the continue button
-    Then the user is returned to the service
-    And the user clicks logout
-
-    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
-    When the user selects sign in
-    Then the user is taken to the "Enter your email" page
-    When the user enters their email address
-    Then the user is taken to the "Enter your password" page
-    When the user enters their password
-    Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
-    When the user enters the security code from the auth app
-    Then the user is taken to the "Sign in faster with your face, fingerprint or passcode - GOV.UK One Login" page
-    When the user chooses to skip passkey registration
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
   Scenario: User successfully login without 2FA
@@ -77,6 +42,7 @@ Feature: Authentication App Journeys
     When the user enters their email address
     Then the user is taken to the "Enter your password" page
     When the user enters their password
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
   Scenario: User signs in auth app without 2FA, then uplifts
@@ -87,6 +53,7 @@ Feature: Authentication App Journeys
     When the user enters their email address
     Then the user is taken to the "Enter your password" page
     When the user enters their password
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
     Then the user comes from the stub relying party with options: [2fa-on,authenticated-2] and is taken to the "Enter a security code to continue" page

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/enforce_100k_password_check.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/enforce_100k_password_check.feature
@@ -15,6 +15,7 @@ Feature: Enforce 100k password check
     When the user enters the six digit security code from their phone
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     And the user logs out
 
@@ -31,5 +32,6 @@ Feature: Enforce 100k password check
     When the user enters the security code from the auth app
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     And the user logs out

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/existing_user_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/existing_user_journey.feature
@@ -20,6 +20,7 @@ Feature: Login Journey
     When the user enters their password
     Then the user is taken to the "Check your phone" page
     When the user enters the six digit security code from their phone
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
   Scenario: Existing user switches content to Welsh
@@ -46,10 +47,12 @@ Feature: Login Journey
     When the user enters their email address
     Then the user is taken to the "Enter your password" page
     When the user enters their password
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     When the user comes from the stub relying party with options: [2fa-on,authenticated-2] and is taken to the "Enter a security code to continue" page
     Then the user is taken to the "Enter a security code to continue" page
     When the user enters the six digit security code from their phone
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     And the user clicks logout
 
@@ -64,9 +67,11 @@ Feature: Login Journey
     When the user enters their password
     Then the user is taken to the "Check your phone" page
     When the user enters the six digit security code from their phone
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     # Second (silent) sign in
     When the user comes from the stub relying party with option authenticated-2
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
   @PasskeyUsageEnabled

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/international_phone_number.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/international_phone_number.feature
@@ -63,6 +63,7 @@ Feature: International phone numbers
       When the user enters the six digit security code from their phone
       Then the user is taken to the "You’ve created your GOV.UK One Login" page
       When the user clicks the continue button
+      And the user dismisses the passkey registration page if present
       Then the user is returned to the service
 
   @InternationalNumbersForcedMFAReset @InternationalSmsSendingEnabled
@@ -88,6 +89,7 @@ Feature: International phone numbers
       When the user enters the six digit security code from their phone
       Then the user is taken to the "You’ve changed how you get security codes" page
       When the user clicks the continue button
+      And the user dismisses the passkey registration page if present
       Then the user is returned to the service
 
   @InternationalNumbersForcedMFAReset @InternationalSmsSendingEnabled
@@ -102,6 +104,7 @@ Feature: International phone numbers
       When the user enters their email address
       Then the user is taken to the "Enter your password" page
       When the user enters their password
+      And the user dismisses the passkey registration page if present
       Then the user is returned to the service
       When the user comes from the stub relying party with options: [2fa-on,authenticated-2] and is taken to the "Enter a security code to continue" page
       When the user enters the six digit security code from their phone
@@ -113,6 +116,7 @@ Feature: International phone numbers
       And the user enters the six digit security code from their phone
       Then the user is taken to the "You’ve changed how you get security codes" page
       When the user clicks the continue button
+      And the user dismisses the passkey registration page if present
       Then the user is returned to the service
 
   @InternationalNumbersForcedMFAReset @InternationalSmsSendingEnabled
@@ -141,6 +145,7 @@ Feature: International phone numbers
       And the user enters the six digit security code from their phone
       Then the user is taken to the "You’ve changed how you get security codes" page
       When the user clicks the continue button
+      And the user dismisses the passkey registration page if present
       Then the user is returned to the service
 
   @InternationalNumbersForcedMFAReset @InternationalSmsSendingEnabled
@@ -192,6 +197,7 @@ Feature: International phone numbers
       And the user enters the six digit security code from their phone
       Then the user is taken to the "You’ve changed how you get security codes" page
       When the user clicks the continue button
+      And the user dismisses the passkey registration page if present
       Then the user is returned to the service
 
     Scenario: User with international SMS MFA is indefinitely locked out when send limit already set
@@ -220,6 +226,7 @@ Feature: International phone numbers
       When the user enters their email address
       Then the user is taken to the "Enter your password" page
       When the user enters their password
+      And the user dismisses the passkey registration page if present
       Then the user is returned to the service
       When the user comes from the stub relying party with options: [2fa-on,authenticated-2] and is taken to the "Enter a security code to continue" page
       When the user requests the phone otp code to the international numbers limit
@@ -236,6 +243,7 @@ Feature: International phone numbers
       When the user enters their email address
       Then the user is taken to the "Enter your password" page
       When the user enters their password
+      And the user dismisses the passkey registration page if present
       Then the user is returned to the service
       When the user comes from the stub relying party with options: [2fa-on,authenticated-2] and is taken to the "Sorry, there’s a problem" page
       When the user selects "Check if you can change how you get security codes" link
@@ -336,6 +344,7 @@ Feature: International phone numbers
       When the user enters their email address
       Then the user is taken to the "Enter your password" page
       When the user enters their password
+      And the user dismisses the passkey registration page if present
       Then the user is returned to the service
       When the user comes from the stub relying party with options: [2fa-on,authenticated-2] and is taken to the "Sorry, there’s a problem" page
       When the user selects "Check if you can change how you get security codes" link

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/legal_and_policy_pages.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/legal_and_policy_pages.feature
@@ -25,6 +25,7 @@ Feature: Legal and policy pages
     When the user enters their password
     Then the user is taken to the "Check your phone" page
     When the user enters the six digit security code from their phone
+    And the user dismisses the passkey registration page if present
     Then the user is taken to the "We’ve updated our terms of use" page
     When the user agrees to the updated terms and conditions
     Then the user is returned to the service

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/mfa_reset.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/mfa_reset.feature
@@ -24,6 +24,7 @@ Feature: The MFA reset process.
     And the user enters the six digit security code from their phone
     Then the user is taken to the "You’ve changed how you get security codes" page
     When the user clicks the continue button
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
 
@@ -44,6 +45,7 @@ Feature: The MFA reset process.
     And the user enters the six digit security code from their phone
     Then the user is taken to the "You’ve changed how you get security codes" page
     When the user clicks the continue button
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
 # ************************* AUTH APP Section *************************
@@ -65,6 +67,7 @@ Feature: The MFA reset process.
     And the user enters the security code from the auth app
     Then the user is taken to the "You’ve changed how you get security codes" page
     When the user clicks the continue button
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
 
@@ -86,6 +89,7 @@ Feature: The MFA reset process.
     And the user enters the security code from the auth app
     Then the user is taken to the "You’ve changed how you get security codes" page
     When the user clicks the continue button
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
 # ************************* Negative tests when for unsuccessful IPV responses **********************
@@ -108,6 +112,7 @@ Feature: The MFA reset process.
     And the user clicks the continue button
     Then the user is taken to the "<Page>" page
     When the user enters the six digit code for "<Mfa Type>"
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     Examples:
       | Mfa Type | Link Text                                     | IPV Response           | Page                                                            |
@@ -168,6 +173,7 @@ Feature: The MFA reset process.
     And the user clicks the continue button
     Then the user is taken to the "<Page>" page
     When the user enters the six digit code for "<Mfa Type>"
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     Examples:
       | Mfa Type | Link Text                                     | IPV Response           | Page                                                            |
@@ -199,6 +205,7 @@ Feature: The MFA reset process.
     And the user clicks the continue button
     Then the user is taken to the "<Page>" page
     When the user enters the six digit code for "<Mfa Type>"
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     Examples:
       | Mfa Type | Link Text                                     | IPV Response              | Page                                                            |
@@ -221,6 +228,7 @@ Feature: The MFA reset process.
     And the user enters the security code from the auth app
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     And the user clicks logout
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -243,6 +251,7 @@ Feature: The MFA reset process.
     When the user enters the six digit security code from their phone
     Then the user is taken to the "You’ve changed how you get security codes" page
     And the user clicks the continue button
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
 
@@ -260,6 +269,7 @@ Feature: The MFA reset process.
     When the user enters the six digit security code from their phone
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     And the user clicks logout
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -281,6 +291,7 @@ Feature: The MFA reset process.
     And the user enters the security code from the auth app
     Then the user is taken to the "You’ve changed how you get security codes" page
     When the user clicks the continue button
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
 
@@ -319,6 +330,7 @@ Feature: The MFA reset process.
     When the user enters the six digit security code from their phone
     Then the user is taken to the "You’ve created your GOV.UK One Login" page
     When the user clicks the continue button
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
 
@@ -339,6 +351,7 @@ Feature: The MFA reset process.
     And the user enters the security code from the auth app
     Then the user is taken to the "You’ve created your GOV.UK One Login" page
     When the user clicks the continue button
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
 
@@ -350,6 +363,7 @@ Feature: The MFA reset process.
     And the user enters their password
     Then the user is taken to the "<Page>" page
     When the user enters the six digit code for "<Mfa Type>"
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
     Examples:

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/reauthentication.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/reauthentication.feature
@@ -120,6 +120,7 @@ Feature: Reauthentication of user
     When the user enters an incorrect password 5 times
     And the user opens up new tab in the same browser, performs a silent log in and switches back to the first tab
     When the user enters an incorrect password 1 times
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
 
@@ -168,6 +169,7 @@ Feature: Reauthentication of user
     And the user enters the six digit security code from their phone
     And the user switches back to the second tab
     And the user enters their email address for reauth
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
 

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/reset_password.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/reset_password.feature
@@ -17,6 +17,7 @@ Feature: Reset password
     When the user enters the six digit security code from their phone
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
   Scenario: An auth app user can successfully reset their password
@@ -35,4 +36,5 @@ Feature: Reset password
     When the user enters the security code from the auth app
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service


### PR DESCRIPTION
## What

- No longer sets up test users with passkeys to bypass passkey setup page
- Adds conditional passkey registration dismissal step
  - If screen is shown, skip, otherwise proceed as normal
- After @ui tests, delete all passkeys a for test user's public subject
  - This is rather than managing through `world`
- There is still the ability to set up a test user with a passkey, as is
  used by `Existing user with a passkey tries to create an account with
  the same email address`. This functionality will be used when explicitly
  testing passkeys functionality.
- Some journeys (e.g. reauth tests) execute test steps in the POM, rather than having their own cucumber steps. I've implemented the passkey registration dismissal there for these tests, but we should align how we do things at some point

## How to review


1. Code Review
2. Deploy acceptance tests alongside related PRs and see a clean sweep in dev (except for international numbers tests which are broken)


## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/3415
https://github.com/govuk-one-login/authentication-api/pull/8372
