### PR TITLE
AUT-5338: Add back UI tag to legal and policy pages feature

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/legal_and_policy_pages.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/legal_and_policy_pages.feature
@@ -1,3 +1,4 @@
+@UI
 Feature: Legal and policy pages
   User clicks on the legal and policy pages
 


### PR DESCRIPTION
Accidentally removed in a [clean up PR](https://github.com/govuk-one-login/authentication-acceptance-tests/pull/900). Adding back in so that it's not run in the account management api tests (not doing any harm there at the moment but doesn't need to be run)

