### PR TITLE
BAU: Fix CVE-2026-42587

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -51,8 +51,11 @@ dependencies {
         testImplementation('org.apache.commons:commons-lang3:[3.20.0,)') {
             because 'CVE-2025-48924 is fixed in org.apache.commons:commons-lang3:3.20.0 and higher'
         }
-        testImplementation('io.netty:netty-codec-http:[4.2.7.Final,)') {
-            because 'CVE-2025-58056 is fixed in io.netty:netty-codec-http:4.2.7.Final and higher'
+        testImplementation('io.netty:netty-codec-http:[4.2.13.Final,5)') {
+            because 'CVE-2026-42587 is fixed in io.netty:netty-codec-http:4.2.13.Final and higher'
+        }
+        testImplementation('io.netty:netty-codec-http2:[4.2.13.Final,5)') {
+            because 'CVE-2026-42587 is fixed in io.netty:netty-codec-http2:4.2.13.Final and higher'
         }
         testImplementation('org.apache.logging.log4j:log4j-core:[2.25.3,3)') {
             because 'CVE-2025-68161 is fixed in org.apache.logging.log4j:log4j-core:2.25.3 and higher'


### PR DESCRIPTION


## What

Fix CVE-2026-42587

Restrict versions of:

- io.netty:netty-codec-http
- io.netty:netty-codec-http2

See https://github.com/govuk-one-login/authentication-acceptance-tests/security/dependabot/26

## How to review

1. Code Review
