### PR TITLE
BAU: Fix CVE-2026-42583

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -57,6 +57,9 @@ dependencies {
         testImplementation('io.netty:netty-codec-http2:[4.2.13.Final,5)') {
             because 'CVE-2026-42587 is fixed in io.netty:netty-codec-http2:4.2.13.Final and higher'
         }
+        testImplementation('io.netty:netty-codec-compression:[4.2.13.Final,5)') {
+            because 'CVE-2026-42583 is fixed in io.netty:netty-codec-compression:4.2.13.Final and higher'
+        }
         testImplementation('org.apache.logging.log4j:log4j-core:[2.25.3,3)') {
             because 'CVE-2025-68161 is fixed in org.apache.logging.log4j:log4j-core:2.25.3 and higher'
         }


### PR DESCRIPTION

## What

Fix CVE-2026-42583

Constrain io.netty:netty-codec-compression

See https://github.com/govuk-one-login/authentication-acceptance-tests/security/dependabot/22

## How to review

1. Code Review

## Related PRs

#906 
