### PR TITLE
Aut 5338/remove deprecated api tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ UI: di-authentication-build
 API: di-auth-staging
 UI: di-authentication-staging
 
-CUCUMBER_FILTER_TAGS are used in each environment to run specific feature groups (@UI or @API).
+CUCUMBER_FILTER_TAGS are used in each environment to run specific feature groups (@UI or @AccountManagementAPI).
 
 #### Environmental Configuration
 Tests depend on environment-specific variables from AWS Systems Manager (SSM) Parameter Store.
@@ -165,7 +165,7 @@ See example below:
 | ACCESSIBILITY_CHECKS | false                        |                                                                                                                                  |
 | FAIL_FAST_ENABLED    | false                        |                                                                                                                                  |
 | PARALLEL_BROWSERS    | 1                            |                                                                                                                                  |
-| CUCUMBER_FILTER_TAGS | "@API"                       |                                                                                                                                  |
+| CUCUMBER_FILTER_TAGS | "@AccountManagementAPI"                       |                                                                                                                                  |
 | AWS_PROFILE          | di-auth-development-admin    |                                                                                                                                  |
 | ENVIRONMENT          | dev                          |                                                                                                                                  |
 ````

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/Hooks.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/Hooks.java
@@ -69,11 +69,11 @@ public class Hooks extends BasePage {
         Driver.closeDriver();
     }
 
-    @After("@API")
+    @After("@AccountManagementAPI")
     public void theUserIsDeleted() {
         if (world.userProfile != null) {
             LOG.info(
-                    "After API hook: Deleting user profile with email {}",
+                    "After Account management API hook: Deleting user profile with email {}",
                     world.userProfile.getEmail());
             userLifecycleService.deleteUserProfileFromDynamodb(world.userProfile);
         }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/UserLifecycleStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/UserLifecycleStepDef.java
@@ -217,7 +217,7 @@ public class UserLifecycleStepDef {
         world.setUserPassword(TOP_100K_PASSWORD);
     }
 
-    //    @After("@UI or @API")
+    //    @After("@UI or @AccountManagementAPI")
     @After("@UI")
     public void theUserIsDeleted() {
         if (world.userProfile != null) {

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/api/account-management/account_management.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/api/account-management/account_management.feature
@@ -1,4 +1,4 @@
-@API @AccountManagementAPI
+@AccountManagementAPI
 Feature: Account Management
 
   Scenario Outline: Authenticated User successfully changes their Phone Number

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/api/account-management/migrated-user-scenarios/mfa-methods-default-auth-app-user.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/api/account-management/migrated-user-scenarios/mfa-methods-default-auth-app-user.feature
@@ -1,4 +1,4 @@
-@API @AccountManagementAPI
+@AccountManagementAPI
 Feature: Auth App MFA User manages their MFA methods via the Method Management API
 
   As an Authenticated User using an Auth App as Default MFA

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/api/account-management/migrated-user-scenarios/mfa-methods-default-sms-user.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/api/account-management/migrated-user-scenarios/mfa-methods-default-sms-user.feature
@@ -1,4 +1,4 @@
-@API @AccountManagementAPI
+@AccountManagementAPI
 Feature: SMS MFA User manages their MFA methods via the Method Management API
 
   As an Authenticated User with a Default MFA of SMS

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/api/account-management/un-migrated-user-scenarios/mfa-methods.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/api/account-management/un-migrated-user-scenarios/mfa-methods.feature
@@ -1,4 +1,4 @@
-@under-development @API @AccountManagementAPI
+@under-development @AccountManagementAPI
 Feature: Auth App MFA User manages their MFA methods via the Method Management API
 
   As an Authenticated User using an Auth App as Default MFA

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/api/account-management/update_email.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/api/account-management/update_email.feature
@@ -1,4 +1,4 @@
-@API @AccountManagementAPI
+@AccountManagementAPI
 Feature: Update Email
 
   Scenario: Authenticated User successfully updates their email address

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/login/using-back-up-mfa.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/login/using-back-up-mfa.feature
@@ -1,4 +1,4 @@
-@API @AccountManagementAPI
+@AccountManagementAPI
 Feature: Login Using Back Up MFA
 
   Scenario Outline: User authenticates using a backup SMS MFA

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/mfa-reset/migrated-users/mfa-reset-migrated.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/mfa-reset/migrated-users/mfa-reset-migrated.feature
@@ -1,4 +1,4 @@
-@mfa-reset @UI @API @AccountManagementAPI
+@mfa-reset @UI @AccountManagementAPI
 
 Feature: The MFA reset process.
   Begins in Authentication, when a user initiates an MFA reset,

--- a/docs/API Testing.md
+++ b/docs/API Testing.md
@@ -195,7 +195,7 @@ public static void authorizeApiGatewayUse(World world) throws ParseException, JO
 ## 7. Best Practices
 
 ### 1. Tagging
-Always tag API test features with `@API` to distinguish them from UI tests
+Always tag Account management API test features with `@AccountManagementAPI` to distinguish them from UI tests
 Use additional tags like `@under-development` for features still in development
 
 ### 2. Separation of Concerns
@@ -203,7 +203,7 @@ Use additional tags like `@under-development` for features still in development
 **Feature Files**: Use business/user terminology only. Focus on what the user wants to achieve, not how it's implemented.
 
 ```gherkin
-  @API
+  @AccountManagementAPI
   Feature: User Profile Management
     Scenario: Update User's Phone Number
       Given the User is Logged In

--- a/docs/API Testing.md
+++ b/docs/API Testing.md
@@ -18,7 +18,7 @@ The API acceptance tests are built using:
 Example from `mfa-methods.feature`:
 
 ```gherkin
-@under-development @API
+@under-development @AccountManagementAPI
 Feature: MFA Method Management API
   Check the MFA Method Management API
   Scenario: Authenticated User successfully Add Backup Phone Number as MFA


### PR DESCRIPTION
## What


Removes the @API tag from tests, hooks and documentation in favour of the more descriptive @AccountManagementAPI tag.

The @AccountManagementAPI tag is preferred since these tests run in two api pipelines:
* The account management api pipeline
* The internal + external api pipeline
and the @API tag actually just picked out account management api tests - the filter params for the internal / external pipeline excluded @API tests which was confusing to look at.

This is part three (final stage) of the move to deprecate the @API tag in favour of the @AccountMangementAPI tag, as the first two stages are now complete:

1. Ensure all @API tests are also tagged as @AccountMangementAPI ✅ 
2. Update all filter tag expressions to reference @AccountManagementAPI instead of @API ✅ 
3. [THIS PR] fully deprecate the @API tag - remove all references in test and update any hooks

## How to review


1. Code Review
1. Ensure no remaining @API tags

## Related PRs

[PR](https://github.com/govuk-one-login/authentication-acceptance-tests/pull/904) that ensured all @API tests were tagged as @AccountManagementAPI