### PR TITLE
AUT-5338: Remove redundant tags for frontend staging pipeline

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/lockouts_account_recovery.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/lockouts_account_recovery.feature
@@ -1,7 +1,6 @@
 @UI @old-mfa-without-ipv
 Feature: Account recovery lockouts
 
-  # ENTER INCORRECT EMAIL OTP TOO MANY TIMES DURING ACCOUNT RECOVERY - 2081 - PASS
   Scenario: A user is blocked when they enter an incorrect email OTP code 6 times during a change of auth method.
     Given a user with SMS MFA exists
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -32,7 +31,6 @@ Feature: Account recovery lockouts
     * the lockout reason is "you entered the wrong security code too many times"
     * the lockout duration is 2 hours
 
-  # REQUEST EMAIL OTP TOO MANY TIMES DURING ACCOUNT RECOVERY - 2382
   Scenario: A user with sms authentication is blocked when they request their email OTP code 6 times during a change of auth method.
     Given a user with SMS MFA exists
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -105,7 +103,6 @@ Feature: Account recovery lockouts
     Then the "You entered the wrong security code too many times" lockout screen is displayed
     * the lockout duration is 15 minutes
 
-  # REQUEST SMS CODE TOO MANY TIMES DURING ACCOUNT RECOVERY - 2380
   Scenario: A user is blocked when they request sms code more than 5 times during a change of auth method.
     Given a user with SMS MFA exists
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -149,7 +146,6 @@ Feature: Account recovery lockouts
     * the lockout duration is 2 hours
 
 
-  # NO LIMIT ON ENTERING INCORRECT AUTH APP CODES DURING ACCOUNT RECOVERY - REG
   Scenario: A user is not blocked when they enter an incorrect auth app code during a change of auth method.
     Given a user with SMS MFA exists
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/lockouts_account_recovery.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/lockouts_account_recovery.feature
@@ -1,4 +1,4 @@
-@UI @lockout_acc_rec @old-mfa-without-ipv
+@UI @old-mfa-without-ipv
 Feature: Account recovery lockouts
 
   # ENTER INCORRECT EMAIL OTP TOO MANY TIMES DURING ACCOUNT RECOVERY - 2081 - PASS

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/reauthentication.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/reauthentication.feature
@@ -202,7 +202,7 @@ Feature: Reauthentication of user
     * the user is not blocked from reauthenticating
 
 
-  @reauth-change-security-code-method-to-auth-app
+  @new-mfa-reset-with-ipv
   Scenario: Sms user can change how they get security codes during reauthentication
     Given a user with SMS MFA exists
     And the user is already signed in to their One Login account
@@ -225,7 +225,7 @@ Feature: Reauthentication of user
     And the user logs out
 
 
-  @reauth-change-security-code-method-to-sms
+  @new-mfa-reset-with-ipv
   Scenario: Auth app user can change how they get security codes during reauthentication
     Given a user with App MFA exists
     And the user is already signed in to their One Login account

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/reauthentication.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/reauthentication.feature
@@ -248,7 +248,6 @@ Feature: Reauthentication of user
 
 
   # WILL BE REPLACED WITH NEW PROCESS IN V3
-  @reauth-pw-reset
   Scenario: User can change their password during reauthenticates
     Given a user with SMS MFA exists
     And the user is already signed in to their One Login account


### PR DESCRIPTION
This PR removes multiple tags from code which were only referenced in the frontend staging pipeline but have all now been removed from the filter parameter as they were unecessary:

* @lockout_acc_rec - frontend staging was excluding this, but the tests in this file were already excluded via other tags, so this was unecessary
* @reauth-pw-reset - frontend staging was excluding this, but it has now been removed as the test passes and there's no reason to exclude it as it makes understanding the logic of which tests are excluded difficult
* some other @reauth-[foo] tags have been replaced with the more general one `@new-mfa-reset-with-ipv` which better explains why some envs need to exclude these tests (the ipv stub doesn't exist in staging)

Also some unnecessary comments removed.

## How to review

1. Code review

