### PR TITLE
AUT-5338: Remove UI tag from test

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/mfa-reset/migrated-users/mfa-reset-migrated.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/mfa-reset/migrated-users/mfa-reset-migrated.feature
@@ -1,4 +1,4 @@
-@UI @AccountManagementAPI
+@AccountManagementAPI
 
 Feature: The MFA reset process.
   Begins in Authentication, when a user initiates an MFA reset,


### PR DESCRIPTION
This test was not previously run in any pipeline, as all the environments worked by excluding either the @UI or the @AccountManagementAPI tags, so a test with both of these tags is not run in any environment.

I'd like to change all the logic of the filter tag expressions to be inclusive of the broad set of tests (so e.g. account management api filter tags would be `@AccountManagementAPI` rather than `not @UI`) to avoid having this footgun in our logic where it's easy to think the test will run everywhere, whereas in fact it runs nowhere.

Making the account management api tag expressions inclusive has been fine since this test file passes in those environments. However, making this change for the internal / external api and frontend pipelines has not been possible, since this test does not pass in those environments due to failing on the account management setup phase.

It should in theory be possible to make these tests pass in those environments, but I've created a spike ticket for this since.

I'm therefore removing the @UI tag from this file which will have no impact on the tests run in each env (since the frontend + internal / external api pipelines never ran this test) but will enable us to make the switch to the filter expression logic and get rid of this footgun.

