### PR TITLE
BAU: Bump io-netty:netty-codec to 4.1.133+

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -158,3 +158,42 @@ task downloadCucumberDependencies {
         configurations.cucumberRuntime.files
     }
 }
+
+task searchForDependency {
+    group = 'Custom'
+    description = 'Find all projects that have a dependency'
+
+    doLast {
+        def targetGroup = project.hasProperty('targetGroup') ? project.property('targetGroup') : null
+        def targetName = project.hasProperty('targetName') ? project.property('targetName') : null
+        def minVersion = project.hasProperty('minVersion') ? project.property('minVersion') : null
+        def parsedMinVersion  = VersionNumber.parse(minVersion)
+
+        println "searching for ${targetGroup}:${targetName} < ${minVersion}\n"
+
+        def foundProjects = new LinkedHashSet<String>()
+
+        allprojects {project ->
+            project.configurations.each { config ->
+                if (config.canBeResolved) {
+                    def resolvedDependencies = config.resolvedConfiguration.lenientConfiguration.allModuleDependencies
+
+                    resolvedDependencies.each { dep ->
+                        if (dep.moduleGroup == targetGroup && dep.moduleName == targetName) {
+                            def parsedResolvedVersion = VersionNumber.parse(dep.getModuleVersion())
+                            def isLower = parsedResolvedVersion < parsedMinVersion
+                            def versionString = isLower
+                                    ? "Version: \u001B[31m${dep.getModuleVersion()}\u001B[0m ⚠️"
+                                    : "Version: \u001B[32m${dep.getModuleVersion()}\u001B[0m ✅"
+                            foundProjects.add(project.path + ":" + config.name +". "  + versionString)
+                        }
+                    }
+                }
+            }
+        }
+
+        foundProjects.each { projectName ->
+            println "${projectName}"
+        }
+    }
+}

--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -54,15 +54,6 @@ dependencies {
         testImplementation('org.apache.commons:commons-lang3:[3.20.0,)') {
             because 'CVE-2025-48924 is fixed in org.apache.commons:commons-lang3:3.20.0 and higher'
         }
-        testImplementation('io.netty:netty-codec-http:[4.2.13.Final,5)') {
-            because 'CVE-2026-42587 is fixed in io.netty:netty-codec-http:4.2.13.Final and higher'
-        }
-        testImplementation('io.netty:netty-codec-http2:[4.2.13.Final,5)') {
-            because 'CVE-2026-42587 is fixed in io.netty:netty-codec-http2:4.2.13.Final and higher'
-        }
-        testImplementation('io.netty:netty-codec-compression:[4.2.13.Final,5)') {
-            because 'CVE-2026-42583 is fixed in io.netty:netty-codec-compression:4.2.13.Final and higher'
-        }
         testImplementation('org.apache.logging.log4j:log4j-core:[2.25.3,3)') {
             because 'CVE-2025-68161 is fixed in org.apache.logging.log4j:log4j-core:2.25.3 and higher'
         }
@@ -71,6 +62,20 @@ dependencies {
         }
         testImplementation('io.opentelemetry:opentelemetry-api:[1.62.0,)') {
             because 'CVE-2026-45292 is fixed in io.opentelemetry:opentelemetry-api:1.62.0 and higher'
+        }
+
+        // Netty
+        testImplementation('io.netty:netty-codec:[4.2.13.Final,5)') {
+            because 'CVE-2026-42583 is fixed in io.netty:netty-codec:4.1.133.Final and higher'
+        }
+        testImplementation('io.netty:netty-codec-http:[4.2.13.Final,5)') {
+            because 'CVE-2026-42587 is fixed in io.netty:netty-codec-http:4.2.13.Final and higher'
+        }
+        testImplementation('io.netty:netty-codec-http2:[4.2.13.Final,5)') {
+            because 'CVE-2026-42587 is fixed in io.netty:netty-codec-http2:4.2.13.Final and higher'
+        }
+        testImplementation('io.netty:netty-codec-compression:[4.2.13.Final,5)') {
+            because 'CVE-2026-42583 is fixed in io.netty:netty-codec-compression:4.2.13.Final and higher'
         }
     }
 }


### PR DESCRIPTION
## What

Constrains `io-netty:netty-codec` to 4.2.13 and above.

The CVE says we should require v4.1.133.Final+, but given that the other Netty libraries were already constrained to 4.2.13, it made sense to force up `netty-codec` too.

## How to review

1. Code Review