### PR TITLE
Bau: clean up tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,13 @@ acceptance tests using Cucumber.
 
 **The test suite consists of two main types of tests:**
 - UI Tests: Browser-based end-to-end tests using Selenium WebDriver to
-validate user journeys through the web interface
+validate user journeys through the web interface. These are generally run in
+both the frontend and the internal / external api pipelines.
 
-- API Tests: Direct validation of account management functionality by
+- Account Management API Tests: Direct validation of account management functionality by
 interacting with AWS services that back the private APIs
+
+All tests will need to be tagged as either @UI or @AccountManagementAPI in order to run in an environment.
 
 The API tests work around the limitation of not being able to directly call
 the private APIs by interacting with the underlying AWS services (DynamoDB, Lambda, etc.)
@@ -91,6 +94,9 @@ These follow a consistent naming pattern:
 - /acceptance-tests/build/RP_URL
 
 These parameters must be present as environment variables during execution.
+
+Refer to https://govukverify.atlassian.net/wiki/spaces/LO/pages/6624215042/Acceptance+test+tags for the current values
+of these tags. Please update this document if updating tags.
 
 ### Running the tests from the command line
 

--- a/README.md
+++ b/README.md
@@ -31,27 +31,6 @@ MFA method updates and user profile changes by manipulating the same backend ser
 - Add details about ad-hoc test runs via the AWS Console
 - Accessibility testing using axe-core
 
-### Repository Structure
-````
-├── acceptance-tests/          # Main test implementation directory
-│   ├── src/test/
-│   │   ├── java/             # Test implementation in Java
-│   │   │   └── uk/gov/di/test/
-│   │   │       ├── entity/   # Data model classes for DynamoDB entities
-│   │   │       ├── pages/    # Page objects for web UI interaction
-│   │   │       ├── services/ # Service layer for AWS interactions
-│   │   │       └── utils/    # Utility classes and helpers
-│   │   └── resources/        # Test resources and feature files
-│   └── build.gradle          # Gradle build configuration for tests
-├── docker/                   # Docker configuration for test execution
-├── gradle/                   # Gradle wrapper and version catalog
-│   ├── libs.versions.toml    # Centralized dependency management
-│   └── wrapper/              # Gradle wrapper files
-├── nginx/                    # Nginx configuration for routing
-├── scripts/                  # Utility scripts for running tests
-└── test-reports/             # Test execution reports (auto-cleaned)
-````
-
 ### Quick Start
 Prerequisites - Ensure the following tools are installed and configured:
 - IntelliJ IDEA (optional but recommended) - Download from https://www.jetbrains.com/idea/

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/existing_user_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/existing_user_journey.feature
@@ -1,4 +1,4 @@
-@UI @Existing
+@UI
 Feature: Login Journey
   Existing user walks through a login journey
 

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/international_phone_number.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/international_phone_number.feature
@@ -65,7 +65,7 @@ Feature: International phone numbers
       When the user clicks the continue button
       Then the user is returned to the service
 
-  @InternationalNumbersForcedMFAReset @InternationalSmsSendingEnabled
+  @InternationalSmsSendingEnabled
   Rule: Forced MFA reset during 2FA sign in
 
     Scenario: User with international SMS MFA successfully completes forced MFA reset during sign in
@@ -90,7 +90,7 @@ Feature: International phone numbers
       When the user clicks the continue button
       Then the user is returned to the service
 
-  @InternationalNumbersForcedMFAReset @InternationalSmsSendingEnabled
+  @InternationalSmsSendingEnabled
   Rule: Forced MFA reset during uplift
 
     Scenario: User with international SMS MFA completes forced MFA reset during uplift after 1FA sign in
@@ -115,7 +115,7 @@ Feature: International phone numbers
       When the user clicks the continue button
       Then the user is returned to the service
 
-  @InternationalNumbersForcedMFAReset @InternationalSmsSendingEnabled
+  @InternationalSmsSendingEnabled
   Rule: Forced MFA reset during password reset
 
     Scenario: User with international SMS MFA completes forced MFA reset during password reset
@@ -143,7 +143,7 @@ Feature: International phone numbers
       When the user clicks the continue button
       Then the user is returned to the service
 
-  @InternationalNumbersForcedMFAReset @InternationalSmsSendingEnabled
+  @InternationalSmsSendingEnabled
   Rule: Forced MFA reset during reauthentication
 
   # Reauth scenarios must start with UK SMS MFA for initial sign-in to succeed,

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/mfa_reset.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/mfa_reset.feature
@@ -1,4 +1,4 @@
-@UI @mfa-reset
+@UI
 
 Feature: The MFA reset process.
   The test below covers jira ticket: AUT-4298, AUT-4051, AUT-3993, AUT-3825, AUT-3930, AUT-3931, AUT-3997

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/registration_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/registration_journey.feature
@@ -1,4 +1,4 @@
-@UI @RegistrationJourney
+@UI
 Feature: Registration Journey
   New user walks through a registration journey
 


### PR DESCRIPTION
## What

* Cleans up some tags that are redundant in code (they do not appear in any of our environment's cucumber filter tags and often repeat the test descriptions)
* Updates the readme to link to the [confluence page on tags](https://govukverify.atlassian.net/wiki/spaces/LO/pages/6624215042/Acceptance+test+tags) (this created as a stopgap until we get the filter tags into infrastructure as code) and adds some info following our recent clean up of tags.

## How to review


1. Code Review commit by commit
1. Compare the tags removed against the tags used in each env (you can see these [here](https://govukverify.atlassian.net/wiki/spaces/LO/pages/6624215042/Acceptance+test+tags)) to check that nothing has been removed which will impact the tests run in each environment
