### PR TITLE
AUT-5420: Skip reauth passkey registration if present

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/login/using-back-up-mfa.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/login/using-back-up-mfa.feature
@@ -733,6 +733,8 @@ Feature: Login Using Back Up MFA
     When the user enters their password
     Then the user is taken to the "Check your phone" page
     When the user enters the six digit security code from their phone
+    And the user dismisses the passkey registration page if present
+    Then the user is returned to the service
     Given the RP requires the user to reauthenticate
     When the user enters the same email address for reauth as they used for login
     And the user enters the correct password
@@ -760,6 +762,8 @@ Feature: Login Using Back Up MFA
     When the user enters their password
     Then the user is taken to the "Check your phone" page
     When the user enters the six digit security code from their phone
+    And the user dismisses the passkey registration page if present
+    Then the user is returned to the service
     Given the RP requires the user to reauthenticate
     When the user enters the same email address for reauth as they used for login
     And the user enters the correct password
@@ -788,6 +792,8 @@ Feature: Login Using Back Up MFA
     When the user enters their password
     Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
     When the user enters the security code from the auth app
+    And the user dismisses the passkey registration page if present
+    Then the user is returned to the service
     Given the RP requires the user to reauthenticate
     When the user enters the same email address for reauth as they used for login
     And the user enters the correct password


### PR DESCRIPTION
## What

- With passkeys registration turned on a passkey registration screen is now shown after sign in in staging
- The screen is skipped if present, if not the test carries on as normal
- `getIdToken()` in the `And the user info JSON is extracted from the stub page` requires the user to be on the orch stub user info screen, so the `Then the user is returned to the service` step has also been added to ensure they're on the right screen.

## How to review

1. Code Review


