### PR TITLE
Bau/update roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,14 @@ You can override environment variables using local .env files:
 - env-override-api.env
 - env-override-ui.env
 
+These files are appended to the generated env file after SSM parameters are fetched,
+so any variable defined here takes precedence over SSM values. The files are created
+automatically if they don't exist and are gitignored.
+
+Example override to hit the account management API:
+````
+NEW_AM_ENV=true
+````
 Example override to skip specific tests:
 ````
 CUCUMBER_FILTER_TAGS="not (@AccountInterventions or @Re-auth or @old-mfa-without-ipv)"
@@ -152,6 +160,7 @@ See example below:
 | PARALLEL_BROWSERS    | 1                            |                                                                                                                                  |
 | CUCUMBER_FILTER_TAGS | "@AccountManagementAPI"                       |                                                                                                                                  |
 | AWS_PROFILE          | di-auth-development-admin    |                                                                                                                                  |
+| NEW_AM_ENV           | true                         | Required to hit the account management API                                                                                       |
 | ENVIRONMENT          | dev                          |                                                                                                                                  |
 ````
 

--- a/rundocker.sh
+++ b/rundocker.sh
@@ -15,7 +15,7 @@ BASE_IMAGE="${2:-}"
 case "${ENVIRONMENT}" in
   authdev*-api)
     TEST_MODE=API
-    AWS_PROFILE=di-auth-development-AdministratorAccessPermission
+    AWS_PROFILE=di-authentication-development-AdministratorAccessPermission
     ENVIRONMENT=${ENVIRONMENT%-*}
     ;;
   authdev*-ui)
@@ -25,7 +25,7 @@ case "${ENVIRONMENT}" in
     ;;
   dev-api)
     TEST_MODE=API
-    AWS_PROFILE=di-auth-development-AdministratorAccessPermission
+    AWS_PROFILE=di-authentication-development-AdministratorAccessPermission
     ENVIRONMENT=dev
     ;;
   dev-ui)
@@ -35,22 +35,22 @@ case "${ENVIRONMENT}" in
     ;;
   build-api)
     TEST_MODE=API
-    AWS_PROFILE=gds-di-development-admin
+    AWS_PROFILE=di-authentication-build-ApprovedAdmin
     ENVIRONMENT=build
     ;;
   build-ui)
     TEST_MODE=UI
-    AWS_PROFILE=di-authentication-build-admin
+    AWS_PROFILE=di-authentication-build-ApprovedAdmin
     ENVIRONMENT=build
     ;;
   staging-api)
     TEST_MODE=API
-    AWS_PROFILE=di-auth-staging-admin
+    AWS_PROFILE=di-authentication-staging-ApprovedAdmin
     ENVIRONMENT=staging
     ;;
   staging-ui)
     TEST_MODE=UI
-    AWS_PROFILE=di-authentication-staging-admin
+    AWS_PROFILE=di-authentication-staging-ApprovedAdmin
     ENVIRONMENT=staging
     ;;
   *)

--- a/rundocker.sh
+++ b/rundocker.sh
@@ -33,26 +33,6 @@ case "${ENVIRONMENT}" in
     AWS_PROFILE=di-authentication-development-AdministratorAccessPermission
     ENVIRONMENT=dev
     ;;
-  build-api)
-    TEST_MODE=API
-    AWS_PROFILE=di-authentication-build-ApprovedAdmin
-    ENVIRONMENT=build
-    ;;
-  build-ui)
-    TEST_MODE=UI
-    AWS_PROFILE=di-authentication-build-ApprovedAdmin
-    ENVIRONMENT=build
-    ;;
-  staging-api)
-    TEST_MODE=API
-    AWS_PROFILE=di-authentication-staging-ApprovedAdmin
-    ENVIRONMENT=staging
-    ;;
-  staging-ui)
-    TEST_MODE=UI
-    AWS_PROFILE=di-authentication-staging-ApprovedAdmin
-    ENVIRONMENT=staging
-    ;;
   *)
     echo "Unconfigured environment: $ENVIRONMENT"
     exit 1


### PR DESCRIPTION
## What

- Update role names for local running
- Remove local running options for upper envs (all envs besides dev). We now use private APIs and don't want bastion access as a way around that

## How to review

1. Code Review
2. Run `rundocker.sh dev-api` script with the following `env-override-api.env`:

```
HOST_ENVIRONMENT="local"
CUCUMBER_FILTER_TAGS="@AccountManagementAPI"
NEW_AM_ENV=true
```

see it runs hitting the AM API successfully. not all tests will pass, primarily international numbers


## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/8450
