### PR TITLE
Aut 5542 migrate gha ad hoc acceptance test

### DIFF
--- a/.github/workflows/build-and-push-adhoc-tests.yaml
+++ b/.github/workflows/build-and-push-adhoc-tests.yaml
@@ -3,8 +3,8 @@ name: Build and push ad hoc acceptance tests
 env:
   AWS_REGION: eu-west-2
   SELENIUM_BASE: selenium/standalone-chromium:132.0
-  AD_HOC_DEV_ECR_REPO: dev-ad-hoc-tests-adhoctestrunnerimagerepository-fxyishxmivqj
-  GHA_DEV_ROLE: arn:aws:iam::653994557586:role/dev-auth-deploy-pipeline-GitHubActionsRole-QrtGginNnjDD
+  AD_HOC_DEV_ECR_REPO: dev-ad-hoc-tests-adhoctestrunnerimagerepository-ghvdzd2cyr46
+  GHA_DEV_ROLE: arn:aws:iam::975050272416:role/authentication-api-pipeline-GitHubActionsRole-eoW45BhwCqWg
 
 on:
   workflow_dispatch:
@@ -42,7 +42,7 @@ jobs:
       - name: Set up AWS credentials
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
-          role-to-assume: ${{ (inputs.environment == 'dev' && env.GHA_DEV_ROLE) || (inputs.environment == 'build' && secrets.GHA_BUILD_ROLE) || (inputs.environment == 'staging' && secrets.GHA_STAGING_ROLE) }}
+          role-to-assume: ${{ env.GHA_DEV_ROLE }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
@@ -58,10 +58,10 @@ jobs:
         with:
           context: .
           push: true
-          target: auth-api
+          target: auth-ad-hoc
           build-args: |
             SELENIUM_BASE=${{ env.SELENIUM_BASE }}
             AD_HOC_CUCUMBER_TAGS=${{ inputs.cucumber_tags }}
-          tags: ${{ format('{0}/{1}:latest', steps.login-ecr.outputs.registry, (inputs.environment == 'dev' && env.AD_HOC_DEV_ECR_REPO) || (inputs.environment == 'build' && secrets.AD_HOC_BUILD_ECR_REPO) || (inputs.environment == 'staging' && secrets.AD_HOC_STAGING_ECR_REPO)) }}
+          tags: ${{ format('{0}/{1}:{2}', steps.login-ecr.outputs.registry, env.AD_HOC_DEV_ECR_REPO, inputs.environment) }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,18 @@ RUN chmod 500 /test/run-acceptance-tests.sh
 ENTRYPOINT ["/test/run-acceptance-tests.sh"]
 
 #
+# The Ad-hoc tests that run in new AWS Account with Assume role in Database account in
+# the root directory of the docker image.
+#
+FROM base AS auth-ad-hoc
+ARG AD_HOC_CUCUMBER_TAGS
+ENV AD_HOC_CUCUMBER_TAGS=${AD_HOC_CUCUMBER_TAGS}
+COPY --chown=${SEL_USER}:${SEL_GROUP} docker/run-tests-ad-hoc.sh /test/run-acceptance-ad-hoc-tests.sh
+RUN chmod 500 /test/run-acceptance-ad-hoc-tests.sh
+
+ENTRYPOINT ["/test/run-acceptance-ad-hoc-tests.sh"]
+
+#
 # The UI tests are run on the secure pipeline which expects a file called run-tests.sh in the root
 # directory of the docker image.
 #

--- a/docker/run-tests-ad-hoc.sh
+++ b/docker/run-tests-ad-hoc.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export ENVIRONMENT="${2}"
+export NEW_AM_ENV=true
+
+check_guard_conditions() {
+  if [ -z "${AWS_REGION:-}" ]; then
+    export AWS_REGION="eu-west-2"
+  fi
+
+}
+
+setup_environment_variables() {
+  if [ ! -f /test/.env ]; then
+    echo "No .env file provided so creating one from SSM."
+    # shellcheck source=../scripts/fetch_envars.sh
+    /test/scripts/fetch_envars.sh "${ENVIRONMENT}" | tee /test/.env
+  fi
+  # shellcheck source=/dev/null
+  set -o allexport && source /test/.env && set +o allexport
+
+  if [ -n "${AD_HOC_CUCUMBER_TAGS:-}" ]; then
+    if [[ ! ${AD_HOC_CUCUMBER_TAGS} =~ ^[a-zA-Z0-9@_-]+(\s+(and|or|not)\s+[a-zA-Z0-9@_()-]+)*$ ]]; then
+      echo "Error: Invalid cucumber tags format: ${AD_HOC_CUCUMBER_TAGS}"
+      exit 1
+    fi
+
+    echo "Value from build-and-push-adhoc-tests workflow present."
+    echo "Overwriting CUCUMBER_FILTER_TAGS value from SSM."
+
+    sed -i '/^CUCUMBER_FILTER_TAGS=/d' /test/.env
+    printf 'CUCUMBER_FILTER_TAGS=%q\n' "${AD_HOC_CUCUMBER_TAGS}" >> /test/.env
+    export CUCUMBER_FILTER_TAGS="${AD_HOC_CUCUMBER_TAGS}"
+  fi
+}
+
+assume_role_to_access_dynamodb_in_api_account() {
+  local cross_account_role_arn
+  case $ENVIRONMENT in
+    dev)
+      cross_account_role_arn="arn:aws:iam::653994557586:role/CrossAccountRole-new-dev"
+      ;;
+    build)
+      cross_account_role_arn="arn:aws:iam::761723964695:role/CrossAccountRole-new-build"
+      ;;
+    staging)
+      cross_account_role_arn="arn:aws:iam::758531536632:role/CrossAccountRole-new-staging"
+      ;;
+  esac
+
+  echo "Assuming cross-account role"
+
+  output=$(aws sts assume-role --role-arn "$cross_account_role_arn" --role-session-name "dynamo-db-access" --output json)
+
+  AWS_ACCESS_KEY_ID="$(echo "$output" | jq -r '.Credentials.AccessKeyId')"
+  export AWS_ACCESS_KEY_ID
+
+  AWS_SECRET_ACCESS_KEY="$(echo "$output" | jq -r '.Credentials.SecretAccessKey')"
+  export AWS_SECRET_ACCESS_KEY
+
+  AWS_SESSION_TOKEN="$(echo "$output" | jq -r '.Credentials.SessionToken')"
+  export AWS_SESSION_TOKEN
+}
+
+log_run_configuration() {
+  if [ -n "${CUCUMBER_FILTER_TAGS:-}" ]; then
+    echo
+    echo "********************************************************************************************"
+    echo "CUCUMBER FILTER TAGS: ${CUCUMBER_FILTER_TAGS}"
+    echo "********************************************************************************************"
+    echo
+  else
+    echo "CUCUMBER_FILTER_TAGS not defined, cannot run tests"
+    exit 1
+  fi
+}
+
+setup_cucumber_run_parameters() {
+  SELENIUM_BROWSER="$(cat /opt/selenium/browser_name)"
+  export SELENIUM_BROWSER
+}
+
+copy_test_reports() {
+  if [ -d "/test/acceptance-tests/target/cucumber-report/" ]; then
+    cp -r /test/acceptance-tests/target/cucumber-report/* "$(pwd)"/results/
+  fi
+}
+
+execute_tests() {
+  local acceptance_tests_exit_status
+
+  pushd /test > /dev/null || exit 1
+  ./gradlew --no-daemon --offline :acceptance-tests:cucumber
+  acceptance_tests_exit_status=$?
+  popd > /dev/null || exit 1
+
+  copy_test_reports
+
+  return $acceptance_tests_exit_status
+}
+
+check_guard_conditions
+setup_cucumber_run_parameters
+setup_environment_variables
+log_run_configuration
+assume_role_to_access_dynamodb_in_api_account
+execute_tests


### PR DESCRIPTION
## What

AUT-5542 : migrate gha ad hoc acceptance test for old AWS account to new Auth AWS account 



## How to review

1. Code Review
1. Deploy the manual workflow to rigger the Ad-hoc test code build in build or Dev  

[Test-dev-ad-hoc-tests] in di-authentication-development

[Test-build-ad-hoc-tests] in di-authentication-build

## Related PRs

