### PR TITLE
BAU: Virtual authenticator configuration (AUT-5002, AUT-4990)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,21 +147,22 @@ PARALLEL_BROWSERS=2
 See example below:
 
 ````
-| Environment Variable | Example Value                | Purpose                                                                                                                          |
-| -------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| SELENIUM_URL         | http://localhost:4445/wd/hub | Local selenium server firefox = 4444, chrome = 4445                                                                              |
-| SELENIUM_BROWSER     | chrome                       | Browser used to run tests - firefox or chrome                                                                                    |
-| SELENIUM_LOCAL       | true                         |                                                                                                                                  |
-| SELENIUM_HEADLESS    | true                         | Run Selenium headless.                                                                                                           |
-| USE_SSM              | true                         | Specifically for running from the IDE. Tells the test runner to use SSM if a required environment variable is undefined locally. |
-| DEBUG_MODE           | false                        | debug mode waits for user entry on OTP screens so you can enter OTP yourself.                                                    |
-| ACCESSIBILITY_CHECKS | false                        |                                                                                                                                  |
-| FAIL_FAST_ENABLED    | false                        |                                                                                                                                  |
-| PARALLEL_BROWSERS    | 1                            |                                                                                                                                  |
-| CUCUMBER_FILTER_TAGS | "@AccountManagementAPI"                       |                                                                                                                                  |
-| AWS_PROFILE          | di-auth-development-admin    |                                                                                                                                  |
-| NEW_AM_ENV           | true                         | Required to hit the account management API                                                                                       |
-| ENVIRONMENT          | dev                          |                                                                                                                                  |
+| Environment Variable      | Example Value                | Purpose                                                                                                                          |
+| ------------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| SELENIUM_URL              | http://localhost:4445/wd/hub | Local selenium server firefox = 4444, chrome = 4445                                                                              |
+| SELENIUM_BROWSER          | chrome                       | Browser used to run tests - firefox or chrome                                                                                    |
+| SELENIUM_LOCAL            | true                         |                                                                                                                                  |
+| SELENIUM_HEADLESS         | true                         | Run Selenium headless.                                                                                                           |
+| USE_SSM                   | true                         | Specifically for running from the IDE. Tells the test runner to use SSM if a required environment variable is undefined locally. |
+| DEBUG_MODE                | false                        | debug mode waits for user entry on OTP screens so you can enter OTP yourself.                                                    |
+| ACCESSIBILITY_CHECKS      | false                        |                                                                                                                                  |
+| FAIL_FAST_ENABLED         | false                        |                                                                                                                                  |
+| PARALLEL_BROWSERS         | 1                            |                                                                                                                                  |
+| CUCUMBER_FILTER_TAGS      | "@AccountManagementAPI"      |                                                                                                                                  |
+| AWS_PROFILE               | di-auth-development-admin    |                                                                                                                                  |
+| NEW_AM_ENV                | true                         | Required to hit the account management API                                                                                       |
+| ENVIRONMENT               | dev                          |                                                                                                                                  |
+| WEBAUTHN_RELYING_PARTY_ID | dev.account.gov.uk           |                                                                                                                                  |
 ````
 
 **First-Time Setup Tips**

--- a/acceptance-tests/src/test/java/uk/gov/di/test/entity/Passkey.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/entity/Passkey.java
@@ -15,6 +15,7 @@ public class Passkey extends Authenticator<Passkey> {
     public static final String ATTRIBUTE_PASSKEY_BACKUP_ELIGIBLE = "PasskeyBackupEligible";
     public static final String ATTRIBUTE_PASSKEY_BACKED_UP = "PasskeyBackedUp";
     public static final String ATTRIBUTE_PASSKEY_IS_RESIDENT_KEY = "PasskeyIsResidentKey";
+    public static final String ATTRIBUTE_PASSKEY_ALGORITHM = "PasskeyAlgorithm";
 
     private String passkeyAaguid;
     private boolean passkeyIsAttested;
@@ -23,6 +24,7 @@ public class Passkey extends Authenticator<Passkey> {
     private boolean passkeyBackupEligible;
     private boolean passkeyBackedUp;
     private boolean passkeyIsResidentKey;
+    private int passkeyAlgorithm;
 
     @Override
     protected Passkey self() {
@@ -129,6 +131,20 @@ public class Passkey extends Authenticator<Passkey> {
 
     public Passkey withPasskeyIsResidentKey(boolean passkeyIsResidentKey) {
         this.passkeyIsResidentKey = passkeyIsResidentKey;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_PASSKEY_ALGORITHM)
+    public int getPasskeyAlgorithm() {
+        return passkeyAlgorithm;
+    }
+
+    public void setPasskeyAlgorithm(int passkeyAlgorithm) {
+        this.passkeyAlgorithm = passkeyAlgorithm;
+    }
+
+    public Passkey withPasskeyAlgorithm(int passkeyAlgorithm) {
+        this.passkeyAlgorithm = passkeyAlgorithm;
         return this;
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/services/PasskeyLifecycleService.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/services/PasskeyLifecycleService.java
@@ -15,6 +15,8 @@ public class PasskeyLifecycleService {
     private static final VirtualAuthenticatorLifecycleService
             VIRTUAL_AUTHENTICATOR_LIFECYCLE_SERVICE =
                     VirtualAuthenticatorLifecycleService.getInstance();
+    private static final TestConfigurationService TEST_CONFIG_SERVICE =
+            TestConfigurationService.getInstance();
 
     private PasskeyLifecycleService() {}
 
@@ -41,7 +43,7 @@ public class PasskeyLifecycleService {
         Credential credential =
                 Credential.createResidentCredential(
                         passkeyConfig.credentialIdAsBytes(),
-                        "dev.account.gov.uk",
+                        TEST_CONFIG_SERVICE.get("WEBAUTHN_RELYING_PARTY_ID"),
                         passkeyConfig.privateKeyAsPkcs8(),
                         publicSubjectId.getBytes(),
                         0);

--- a/acceptance-tests/src/test/java/uk/gov/di/test/services/PasskeyLifecycleService.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/services/PasskeyLifecycleService.java
@@ -1,15 +1,20 @@
 package uk.gov.di.test.services;
 
+import org.openqa.selenium.virtualauthenticator.Credential;
 import uk.gov.di.test.entity.Passkey;
+import uk.gov.di.test.utils.PasskeyConfig;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 
 public class PasskeyLifecycleService {
     private static volatile PasskeyLifecycleService instance;
 
     private static final DynamoDbService DYNAMO_DB_SERVICE = DynamoDbService.getInstance();
+    private static final VirtualAuthenticatorLifecycleService
+            VIRTUAL_AUTHENTICATOR_LIFECYCLE_SERVICE =
+                    VirtualAuthenticatorLifecycleService.getInstance();
 
     private PasskeyLifecycleService() {}
 
@@ -24,21 +29,40 @@ public class PasskeyLifecycleService {
         return instance;
     }
 
-    public void buildAndStorePasskey(String publicSubjectId) {
-        var testPasskeyId = UUID.randomUUID().toString();
+    public void buildAndStorePasskey(String publicSubjectId) throws Exception {
+        var passkeyConfig = PasskeyConfig.generatePasskeyConfig();
 
-        putPasskeyInDynamo(publicSubjectId, testPasskeyId);
+        putPasskeyInAuthenticator(publicSubjectId, passkeyConfig);
+        putPasskeyInDynamo(publicSubjectId, passkeyConfig);
     }
 
-    private void putPasskeyInDynamo(String publicSubjectId, String testPasskeyId) {
+    private static void putPasskeyInAuthenticator(
+            String publicSubjectId, PasskeyConfig passkeyConfig) {
+        Credential credential =
+                Credential.createResidentCredential(
+                        passkeyConfig.credentialIdAsBytes(),
+                        "dev.account.gov.uk",
+                        passkeyConfig.privateKeyAsPkcs8(),
+                        publicSubjectId.getBytes(),
+                        0);
+
+        VIRTUAL_AUTHENTICATOR_LIFECYCLE_SERVICE.putCredentialInAuthenticator(credential);
+    }
+
+    private void putPasskeyInDynamo(String publicSubjectId, PasskeyConfig passkeyConfig) {
         var created = LocalDateTime.now().toString();
         var passkey =
                 new Passkey()
                         .withPublicSubjectId(publicSubjectId)
-                        .withSortKey(buildSortKey(testPasskeyId))
-                        .withCredentialId(testPasskeyId)
+                        .withSortKey(buildSortKey(passkeyConfig.credentialIdAsBase64Url()))
                         .withCreated(created)
-                        .withCredential("testCredential");
+                        .withCredential(passkeyConfig.publicKeyAsCoseBase64Url())
+                        .withCredentialId(passkeyConfig.credentialIdAsBase64Url())
+                        .withPasskeyAaguid("00000000-0000-0000-0000-000000000000")
+                        .withPasskeySignCount(0)
+                        .withPasskeyTransports(Collections.singletonList("usb"))
+                        .withPasskeyIsResidentKey(true)
+                        .withPasskeyAlgorithm(-7);
 
         DYNAMO_DB_SERVICE.putPasskey(passkey);
     }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/services/PasskeyLifecycleService.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/services/PasskeyLifecycleService.java
@@ -24,8 +24,13 @@ public class PasskeyLifecycleService {
         return instance;
     }
 
-    public List<Passkey> buildPasskeyAndPutToDynamoDb(String publicSubjectId) {
+    public void buildAndStorePasskey(String publicSubjectId) {
         var testPasskeyId = UUID.randomUUID().toString();
+
+        putPasskeyInDynamo(publicSubjectId, testPasskeyId);
+    }
+
+    private void putPasskeyInDynamo(String publicSubjectId, String testPasskeyId) {
         var created = LocalDateTime.now().toString();
         var passkey =
                 new Passkey()
@@ -36,7 +41,6 @@ public class PasskeyLifecycleService {
                         .withCredential("testCredential");
 
         DYNAMO_DB_SERVICE.putPasskey(passkey);
-        return List.of(passkey);
     }
 
     public void deleteAllPasskeysForUser(String publicSubjectId) {

--- a/acceptance-tests/src/test/java/uk/gov/di/test/services/VirtualAuthenticatorLifecycleService.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/services/VirtualAuthenticatorLifecycleService.java
@@ -37,4 +37,12 @@ public class VirtualAuthenticatorLifecycleService {
 
         authenticator = driver.addVirtualAuthenticator(options);
     }
+
+    public void destroyVirtualAuthenticator() {
+        if (authenticator == null) return;
+
+        var driver = Driver.getAsAuthenticator();
+        driver.removeVirtualAuthenticator(authenticator);
+        authenticator = null;
+    }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/services/VirtualAuthenticatorLifecycleService.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/services/VirtualAuthenticatorLifecycleService.java
@@ -50,4 +50,8 @@ public class VirtualAuthenticatorLifecycleService {
     public void putCredentialInAuthenticator(Credential credential) {
         authenticator.addCredential(credential);
     }
+
+    public void disableUserVerification() {
+        authenticator.setUserVerified(false);
+    }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/services/VirtualAuthenticatorLifecycleService.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/services/VirtualAuthenticatorLifecycleService.java
@@ -1,0 +1,40 @@
+package uk.gov.di.test.services;
+
+import org.openqa.selenium.virtualauthenticator.VirtualAuthenticator;
+import org.openqa.selenium.virtualauthenticator.VirtualAuthenticatorOptions;
+import uk.gov.di.test.utils.Driver;
+
+public class VirtualAuthenticatorLifecycleService {
+    private static volatile VirtualAuthenticatorLifecycleService instance;
+    private VirtualAuthenticator authenticator;
+
+    private VirtualAuthenticatorLifecycleService() {}
+
+    public static VirtualAuthenticatorLifecycleService getInstance() {
+        if (instance == null) {
+            synchronized (VirtualAuthenticatorLifecycleService.class) {
+                if (instance == null) {
+                    instance = new VirtualAuthenticatorLifecycleService();
+                }
+            }
+        }
+        return instance;
+    }
+
+    public void createVirtualAuthenticator() {
+        if (authenticator != null) {
+            throw new UnsupportedOperationException(
+                    "Cannot create a second virtual authenticator while one is already attached");
+        }
+
+        var driver = Driver.getAsAuthenticator();
+
+        VirtualAuthenticatorOptions options =
+                new VirtualAuthenticatorOptions()
+                        .setHasResidentKey(true)
+                        .setHasUserVerification(true)
+                        .setIsUserVerified(true);
+
+        authenticator = driver.addVirtualAuthenticator(options);
+    }
+}

--- a/acceptance-tests/src/test/java/uk/gov/di/test/services/VirtualAuthenticatorLifecycleService.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/services/VirtualAuthenticatorLifecycleService.java
@@ -1,5 +1,6 @@
 package uk.gov.di.test.services;
 
+import org.openqa.selenium.virtualauthenticator.Credential;
 import org.openqa.selenium.virtualauthenticator.VirtualAuthenticator;
 import org.openqa.selenium.virtualauthenticator.VirtualAuthenticatorOptions;
 import uk.gov.di.test.utils.Driver;
@@ -44,5 +45,9 @@ public class VirtualAuthenticatorLifecycleService {
         var driver = Driver.getAsAuthenticator();
         driver.removeVirtualAuthenticator(authenticator);
         authenticator = null;
+    }
+
+    public void putCredentialInAuthenticator(Credential credential) {
+        authenticator.addCredential(credential);
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/Hooks.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/Hooks.java
@@ -18,6 +18,7 @@ import java.util.Calendar;
 
 import static uk.gov.di.test.step_definitions.UserLifecycleStepDef.passkeyLifecycleService;
 import static uk.gov.di.test.step_definitions.UserLifecycleStepDef.userLifecycleService;
+import static uk.gov.di.test.step_definitions.UserLifecycleStepDef.virtualAuthenticatorLifecycleService;
 
 public class Hooks extends BasePage {
     private static final Logger LOG = LogManager.getLogger(Hooks.class);
@@ -44,12 +45,17 @@ public class Hooks extends BasePage {
         AxeStepDef.thereAreNoAccessibilityViolations();
     }
 
-    @After("@UI")
-    public void afterEachUI() {
+    @After(value = "@UI", order = 3)
+    public void deleteAllCookies() {
         Driver.get().manage().deleteAllCookies();
     }
 
-    @After("@UI")
+    @After(value = "@UI", order = 2)
+    public void destroyVirtualAuthenticator() {
+        virtualAuthenticatorLifecycleService.destroyVirtualAuthenticator();
+    }
+
+    @After(value = "@UI", order = 1)
     public void takeScreenshotOnFailure(Scenario scenario) {
         if (scenario.isFailed()) {
             WebDriver driver = Driver.get();

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/PasskeysStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/PasskeysStepDef.java
@@ -5,10 +5,13 @@ import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import uk.gov.di.test.pages.BasePage;
 import uk.gov.di.test.pages.CreatePasskeysPage;
+import uk.gov.di.test.services.VirtualAuthenticatorLifecycleService;
 
 public class PasskeysStepDef extends BasePage {
 
     public CreatePasskeysPage createPasskeysPage;
+    public static final VirtualAuthenticatorLifecycleService virtualAuthenticatorLifecycleService =
+            VirtualAuthenticatorLifecycleService.getInstance();
 
     public PasskeysStepDef() {
         this.createPasskeysPage = new CreatePasskeysPage();
@@ -27,5 +30,10 @@ public class PasskeysStepDef extends BasePage {
     @And("the user dismisses the passkey registration page if present")
     public void dismissPasskeyRegistrationPageIfPresent() {
         createPasskeysPage.dismissIfPresent();
+    }
+
+    @And("the user will fail verification")
+    public void willFailVerification() {
+        virtualAuthenticatorLifecycleService.disableUserVerification();
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/UserLifecycleStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/UserLifecycleStepDef.java
@@ -9,6 +9,7 @@ import uk.gov.di.test.services.PasskeyLifecycleService;
 import uk.gov.di.test.services.PhoneNumberLifecycleService;
 import uk.gov.di.test.services.TestConfigurationService;
 import uk.gov.di.test.services.UserLifecycleService;
+import uk.gov.di.test.services.VirtualAuthenticatorLifecycleService;
 
 import static uk.gov.di.test.services.UserLifecycleService.generateValidPassword;
 import static uk.gov.di.test.utils.Constants.TOP_100K_PASSWORD;
@@ -24,6 +25,8 @@ public class UserLifecycleStepDef {
             TestConfigurationService.getInstance();
     public static final PasskeyLifecycleService passkeyLifecycleService =
             PasskeyLifecycleService.getInstance();
+    public static final VirtualAuthenticatorLifecycleService virtualAuthenticatorLifecycleService =
+            VirtualAuthenticatorLifecycleService.getInstance();
 
     public UserLifecycleStepDef(World world) {
         this.world = world;
@@ -113,6 +116,7 @@ public class UserLifecycleStepDef {
     @Given("a user exists with a passkey")
     public void aUserExistsWithAPasskey() {
         aUserExists();
+        virtualAuthenticatorLifecycleService.createVirtualAuthenticator();
         passkeyLifecycleService.buildAndStorePasskey(world.userProfile.getPublicSubjectID());
     }
 

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/UserLifecycleStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/UserLifecycleStepDef.java
@@ -113,8 +113,7 @@ public class UserLifecycleStepDef {
     @Given("a user exists with a passkey")
     public void aUserExistsWithAPasskey() {
         aUserExists();
-        passkeyLifecycleService.buildPasskeyAndPutToDynamoDb(
-                world.userProfile.getPublicSubjectID());
+        passkeyLifecycleService.buildAndStorePasskey(world.userProfile.getPublicSubjectID());
     }
 
     @Given("a user with unique international SMS MFA exists")

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/UserLifecycleStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/UserLifecycleStepDef.java
@@ -114,7 +114,7 @@ public class UserLifecycleStepDef {
     }
 
     @Given("a user exists with a passkey")
-    public void aUserExistsWithAPasskey() {
+    public void aUserExistsWithAPasskey() throws Exception {
         aUserExists();
         virtualAuthenticatorLifecycleService.createVirtualAuthenticator();
         passkeyLifecycleService.buildAndStorePasskey(world.userProfile.getPublicSubjectID());

--- a/acceptance-tests/src/test/java/uk/gov/di/test/utils/CoseKeyEncoder.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/utils/CoseKeyEncoder.java
@@ -1,0 +1,51 @@
+package uk.gov.di.test.utils;
+
+import java.io.ByteArrayOutputStream;
+import java.security.interfaces.ECPublicKey;
+import java.util.Base64;
+
+/**
+ * When storing the passkey public key in the database, it's required in COSE Base64URL encoded
+ * format. This is a utility class to an EC P-256 public key into that format.
+ */
+public class CoseKeyEncoder {
+
+    private CoseKeyEncoder() {}
+
+    public static String ecPublicKeyToCoseBase64Url(ECPublicKey publicKey) {
+        byte[] x = toUnsignedFixedLength(publicKey.getW().getAffineX().toByteArray(), 32);
+        byte[] y = toUnsignedFixedLength(publicKey.getW().getAffineY().toByteArray(), 32);
+
+        // CBOR map with 5 entries: {1:2, 3:-7, -1:1, -2:x, -3:y}
+        ByteArrayOutputStream out = new ByteArrayOutputStream(77);
+        out.write(0xa5); // map(5)
+        out.write(0x01); // key: 1 (kty)
+        out.write(0x02); // value: 2 (EC2)
+        out.write(0x03); // key: 3 (alg)
+        out.write(0x26); // value: -7 (ES256)
+        out.write(0x20); // key: -1 (crv)
+        out.write(0x01); // value: 1 (P-256)
+        out.write(0x21); // key: -2 (x)
+        out.write(0x58); // bytes, 1-byte length follows
+        out.write(0x20); // length: 32
+        out.writeBytes(x);
+        out.write(0x22); // key: -3 (y)
+        out.write(0x58); // bytes, 1-byte length follows
+        out.write(0x20); // length: 32
+        out.writeBytes(y);
+
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(out.toByteArray());
+    }
+
+    private static byte[] toUnsignedFixedLength(byte[] bigIntBytes, int length) {
+        if (bigIntBytes.length == length) return bigIntBytes;
+        byte[] result = new byte[length];
+        if (bigIntBytes.length > length) {
+            System.arraycopy(bigIntBytes, bigIntBytes.length - length, result, 0, length);
+        } else {
+            System.arraycopy(
+                    bigIntBytes, 0, result, length - bigIntBytes.length, bigIntBytes.length);
+        }
+        return result;
+    }
+}

--- a/acceptance-tests/src/test/java/uk/gov/di/test/utils/Driver.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/utils/Driver.java
@@ -6,6 +6,7 @@ import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.virtualauthenticator.HasVirtualAuthenticator;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -21,7 +22,6 @@ public class Driver {
     protected static final Boolean SELENIUM_HEADLESS =
             Boolean.valueOf(Environment.getOrThrow("SELENIUM_HEADLESS"));
     protected static final String SELENIUM_BROWSER = Environment.getOrThrow("SELENIUM_BROWSER");
-    protected static WebDriver driver;
     private static final InheritableThreadLocal<WebDriver> driverPool =
             new InheritableThreadLocal<>();
 
@@ -82,6 +82,15 @@ public class Driver {
                         .setPosition(new org.openqa.selenium.Point(100, 100));
             }
         return driverPool.get();
+    }
+
+    public static HasVirtualAuthenticator getAsAuthenticator() {
+        var d = get();
+        if (d instanceof HasVirtualAuthenticator) {
+            return (HasVirtualAuthenticator) d;
+        }
+        throw new UnsupportedOperationException(
+                "The current driver does not support Virtual Authenticators");
     }
 
     private static ChromeOptions buildChromeOptions() {

--- a/acceptance-tests/src/test/java/uk/gov/di/test/utils/PasskeyConfig.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/utils/PasskeyConfig.java
@@ -1,0 +1,62 @@
+package uk.gov.di.test.utils;
+
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+
+public class PasskeyConfig {
+    private final byte[] credentialIdAsBytes;
+    private final String credentialIdAsBase64Url;
+    private final PKCS8EncodedKeySpec privateKeyAsPkcs8;
+    private final String publicKeyAsCoseBase64Url;
+
+    public static PasskeyConfig generatePasskeyConfig() throws Exception {
+        return new PasskeyConfig();
+    }
+
+    private PasskeyConfig() throws Exception {
+        this.credentialIdAsBytes = generateCredentialIdBytes();
+        this.credentialIdAsBase64Url =
+                Base64.getUrlEncoder().withoutPadding().encodeToString(credentialIdAsBytes);
+
+        KeyPair keyPair = generateWebAuthnKeyPair();
+        this.privateKeyAsPkcs8 = new PKCS8EncodedKeySpec(keyPair.getPrivate().getEncoded());
+        this.publicKeyAsCoseBase64Url =
+                CoseKeyEncoder.ecPublicKeyToCoseBase64Url((ECPublicKey) keyPair.getPublic());
+    }
+
+    private static byte[] generateCredentialIdBytes() {
+        byte[] credentialIdBytes = new byte[32];
+        new SecureRandom().nextBytes(credentialIdBytes);
+        return credentialIdBytes;
+    }
+
+    private static KeyPair generateWebAuthnKeyPair()
+            throws NoSuchAlgorithmException, InvalidAlgorithmParameterException {
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("EC");
+        keyGen.initialize(new ECGenParameterSpec("secp256r1"));
+        return keyGen.generateKeyPair();
+    }
+
+    public byte[] credentialIdAsBytes() {
+        return credentialIdAsBytes;
+    }
+
+    public String credentialIdAsBase64Url() {
+        return credentialIdAsBase64Url;
+    }
+
+    public PKCS8EncodedKeySpec privateKeyAsPkcs8() {
+        return privateKeyAsPkcs8;
+    }
+
+    public String publicKeyAsCoseBase64Url() {
+        return publicKeyAsCoseBase64Url;
+    }
+}

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/passkeys.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/passkeys.feature
@@ -95,3 +95,14 @@ Feature: Passkeys
     When "Back" radio option selected
     And the user clicks the continue button
     Then the user is taken to the "Sign in faster with your face, fingerprint or passcode - GOV.UK One Login" page
+
+  @PasskeyUsageEnabled
+  Scenario: Existing user with a passkey sign in
+    Given a user exists with a passkey
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email address" page
+    When the user enters their email address
+    Then the user is taken to the "Sign in with your face, fingerprint or passcode" page
+    When the user clicks the continue button
+    Then the user is returned to the service

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/passkeys.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/passkeys.feature
@@ -106,3 +106,15 @@ Feature: Passkeys
     Then the user is taken to the "Sign in with your face, fingerprint or passcode" page
     When the user clicks the continue button
     Then the user is returned to the service
+
+  @PasskeyUsageEnabled
+  Scenario: User is routed to error page when passkey authentication fails
+    Given a user exists with a passkey
+    And the user will fail verification
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email address" page
+    When the user enters their email address
+    Then the user is taken to the "Sign in with your face, fingerprint or passcode" page
+    When the user clicks the continue button
+    Then the user is taken to the "We could not sign you in" page


### PR DESCRIPTION
## What

Sets up the virtual authenticator within our acceptance tests. This allows us to add test passkeys and perform an actual authentication ceremony.

Have also implemented the tests that were missing for AUT-5002 and AUT-4990 to test the principle.

## How to review

1. Code Review
1. Run against dev and ensure the new tests pass