### PR TITLE
AUT-5001: User successfully retries signing in using passkey

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/services/VirtualAuthenticatorLifecycleService.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/services/VirtualAuthenticatorLifecycleService.java
@@ -51,6 +51,10 @@ public class VirtualAuthenticatorLifecycleService {
         authenticator.addCredential(credential);
     }
 
+    public void enableUserVerification() {
+        authenticator.setUserVerified(true);
+    }
+
     public void disableUserVerification() {
         authenticator.setUserVerified(false);
     }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/PasskeysStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/PasskeysStepDef.java
@@ -1,6 +1,7 @@
 package uk.gov.di.test.step_definitions;
 
 import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import uk.gov.di.test.pages.BasePage;
@@ -32,7 +33,12 @@ public class PasskeysStepDef extends BasePage {
         createPasskeysPage.dismissIfPresent();
     }
 
-    @And("the user will fail verification")
+    @Given("the user will succeed verification")
+    public void willSucceedVerification() {
+        virtualAuthenticatorLifecycleService.enableUserVerification();
+    }
+
+    @Given("the user will fail verification")
     public void willFailVerification() {
         virtualAuthenticatorLifecycleService.disableUserVerification();
     }

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/passkeys.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/passkeys.feature
@@ -118,3 +118,19 @@ Feature: Passkeys
     Then the user is taken to the "Sign in with your face, fingerprint or passcode" page
     When the user clicks the continue button
     Then the user is taken to the "We could not sign you in" page
+
+  @PasskeyUsageEnabled
+  Scenario: Successful passkey retry signs the user in
+    Given a user exists with a passkey
+    And the user will fail verification
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email address" page
+    When the user enters their email address
+    Then the user is taken to the "Sign in with your face, fingerprint or passcode" page
+    When the user clicks the continue button
+    Then the user is taken to the "We could not sign you in" page
+
+    Given the user will succeed verification
+    When the user selects radio button "Try signing in with your passkey again"
+    Then the user is returned to the service


### PR DESCRIPTION
## What

Simulates a failed passkey usage, followed by a successful retry from the `/cannot-sign-in-passkey` page.

Required adding a new step def to toggle-on successful user verification. Changed the existing toggle-off step def to also use `Given` (as this is a configuration step).

## How to review

1. Code Review
1. Run locally against the dev environment