### PR TITLE
AUT-5000: Add acceptance tests for the retry and fallback options on the cannot-sign-in-passkey page

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,11 @@
+ENVIRONMENT=dev
 # Run Selenium headless.  Set to false to see the tests run in a the browser
-SELENIUM_HEADLESS=true
+SELENIUM_HEADLESS=false
+DEBUG_MODE=false
+USE_SSM=true
 ACCESSIBILITY_CHECKS=false
+PARALLEL_BROWSERS=1
+NEW_AM_ENV=true
 FAIL_FAST_ENABLED=false
-PARALLEL_BROWSERS=4
+AWS_PROFILE=di-authentication-development-AdministratorAccessPermission
+WEBAUTHN_RELYING_PARTY_ID=dev.account.gov.uk

--- a/.run/Template Cucumber Java.run.xml
+++ b/.run/Template Cucumber Java.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="true" type="CucumberJavaRunConfigurationType" factoryName="Cucumber java">
+    <option name="envFilePaths">
+      <option value="$PROJECT_DIR$/.env" />
+    </option>
+    <shortenClasspath name="NONE" />
+    <option name="WORKING_DIRECTORY" value="$MODULE_WORKING_DIR$" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/README.md
+++ b/README.md
@@ -142,48 +142,52 @@ PARALLEL_BROWSERS=2
 
 ### Running the tests from IntelliJ
 
-**Create a run configuration using a .env file to provide environment variables**
-See example below:
+You can run individual tests locally from IntelliJ against the dev environment.
+This uses a local browser via Selenium rather than the Dockerised setup.
 
-````
-| Environment Variable      | Example Value                | Purpose                                                                                                                          |
-| ------------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| SELENIUM_HEADLESS         | true                         | Run Selenium headless.                                                                                                           |
-| USE_SSM                   | true                         | Specifically for running from the IDE. Tells the test runner to use SSM if a required environment variable is undefined locally. |
-| DEBUG_MODE                | false                        | debug mode waits for user entry on OTP screens so you can enter OTP yourself.                                                    |
-| ACCESSIBILITY_CHECKS      | false                        |                                                                                                                                  |
-| FAIL_FAST_ENABLED         | false                        |                                                                                                                                  |
-| PARALLEL_BROWSERS         | 1                            |                                                                                                                                  |
-| CUCUMBER_FILTER_TAGS      | "@AccountManagementAPI"      |                                                                                                                                  |
-| AWS_PROFILE               | di-auth-development-admin    |                                                                                                                                  |
-| NEW_AM_ENV                | true                         | Required to hit the account management API                                                                                       |
-| ENVIRONMENT               | dev                          |                                                                                                                                  |
-| WEBAUTHN_RELYING_PARTY_ID | dev.account.gov.uk           |                                                                                                                                  |
+#### Prerequisites
+- AWS CLI configured with SSO profile `di-authentication-development-AdministratorAccessPermission`
+- Connected to the VPN
+
+#### Step 1: Log in to AWS via SSO
+
+Run the following commands to log in to your AWS account as an admin in the dev account
+
+````bash
+export AWS_PROFILE=di-authentication-development-AdministratorAccessPermission
+source ./scripts/check_aws_creds.sh
 ````
 
-**First-Time Setup Tips**
-- Use chmod +x gradlew if the Gradle wrapper lacks execution permissions.
-- Pull latest Selenium images regularly:
-  - docker pull selenium/standalone-chrome
-- Ensure Docker is running and not blocked by firewall or VPN.
-- Test reports are automatically managed in the test-reports/ directory.
+You will need to re-run this when your AWS session expires or SSM parameters change.
 
-**Deployment**
+#### Step 2: Copy .env.sample into a local .env file
+
+The shared Cucumber run configuration template (`.run/Template Cucumber Java.run.xml`) is already set up to read from `.env`.
+
+#### Step 3: Run a test from IntelliJ
+
+__Note__: If tests fail with authentication errors, run commands in step 1 to refresh credentials.
+
+### Deployment
+
 Tests are deployed using GitHub Actions:
 - Use "Build and Push to API DEV account" to deploy to API
 - Use "Build and Push to UI DEV account" to deploy to UI
 
-**The workflow:**
+The workflow:
 - Builds test containers (Chrome)
 - Pushes images to ECR
 - Tags for the development environment
 
-**Build System**
+### Build System
+
 The project uses Gradle 8 with modern best practices:
 - Version catalog (`gradle/libs.versions.toml`) for centralized dependency management
 - No root build.gradle (single subproject structure)
 - Optimized build performance with caching and parallel execution
 - Java 17 compatibility
+
+### Architecture
 
 **Data Flow**
 
@@ -195,7 +199,7 @@ v                                                         v
 (DynamoDB, SSM)
 ````
 
-### Component Interactions
+**Component Interactions**
 - **Test Runner:** Executes Cucumber features using Gradle 8
 - **Selenium WebDriver:** Drives browser automation
 - **Page Objects:** Abstract web interactions

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/back_button_behaviour.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/back_button_behaviour.feature
@@ -1,4 +1,4 @@
-@UI @PasskeysEnabled
+@UI
 Feature: Back Button Behaviour
 
   Scenario: User can navigate to reset-password-check-email and navigate back through each page
@@ -28,3 +28,19 @@ Feature: Back Button Behaviour
     Then the user is taken to the "Enter your email" page
     When the user clicks the Back link
     Then the user is taken to the "Create your GOV.UK One Login or sign in" page
+
+  @PasskeyUsageEnabled
+  Scenario: User can go back to sign in with a passkey from enter-password
+    Given a user exists with a passkey
+    And the user will fail verification
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email address" page
+    When the user enters their email address
+    Then the user is taken to the "Sign in with your face, fingerprint or passcode" page
+    When the user clicks the continue button
+    Then the user is taken to the "We could not sign you in" page
+    When the user selects radio button "Sign in with your password"
+    Then the user is taken to the "Enter your password" page
+    When the user clicks the Back link
+    Then the user is taken to the "We could not sign you in" page

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/passkeys.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/passkeys.feature
@@ -144,3 +144,36 @@ Feature: Passkeys
     Then the user is taken to the "Enter your email address" page
     When the user enters their email address
     Then the user is taken to the "Enter your password" page
+
+  @PasskeyUsageEnabled
+  Scenario: User can retry passkey sign in multiple times
+    Given a user exists with a passkey
+    And the user will fail verification
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email address" page
+    When the user enters their email address
+    Then the user is taken to the "Sign in with your face, fingerprint or passcode" page
+    When the user clicks the continue button
+    Then the user is taken to the "We could not sign you in" page
+    Given the user will fail verification
+    When the user selects radio button "Try signing in with your passkey again"
+    Then the user is taken to the "We could not sign you in" page
+
+    Given the user will succeed verification
+    When the user selects radio button "Try signing in with your passkey again"
+    Then the user is returned to the service
+
+  @PasskeyUsageEnabled
+  Scenario: User can choose to sign in with password if passkey sign in fails
+    Given a user exists with a passkey
+    And the user will fail verification
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email address" page
+    When the user enters their email address
+    Then the user is taken to the "Sign in with your face, fingerprint or passcode" page
+    When the user clicks the continue button
+    Then the user is taken to the "We could not sign you in" page
+    When the user selects radio button "Sign in with your password"
+    Then the user is taken to the "Enter your password" page


### PR DESCRIPTION
## What

The user can now try signing in with their password and mfa when passkey sign in fails. They can also retry signing in as many times as they want. These cases are covered by these tests

## How to review

1. Code review
2. Run against dev

## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/3463
