### PR TITLE
BAU: Fix rundocker script

### DIFF
--- a/.github/workflows/build-and-push-adhoc-tests.yaml
+++ b/.github/workflows/build-and-push-adhoc-tests.yaml
@@ -2,7 +2,7 @@ name: Build and push ad hoc acceptance tests
 
 env:
   AWS_REGION: eu-west-2
-  SELENIUM_BASE: selenium/standalone-chromium:132.0
+  SELENIUM_BASE: selenium/standalone-chromium:148.0
   AD_HOC_DEV_ECR_REPO: dev-ad-hoc-tests-adhoctestrunnerimagerepository-ghvdzd2cyr46
   GHA_DEV_ROLE: arn:aws:iam::975050272416:role/authentication-api-pipeline-GitHubActionsRole-eoW45BhwCqWg
 

--- a/.github/workflows/build-and-push-tests-SP-dev.yaml
+++ b/.github/workflows/build-and-push-tests-SP-dev.yaml
@@ -2,7 +2,7 @@ name: Build and Push to UI DEV account
 
 env:
   AWS_REGION: eu-west-2
-  SELENIUM_BASE: selenium/standalone-chromium:132.0
+  SELENIUM_BASE: selenium/standalone-chromium:148.0
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build-and-push-tests-SP.yaml
+++ b/.github/workflows/build-and-push-tests-SP.yaml
@@ -2,7 +2,7 @@ name: Build and Push Tests Secure Pipeline
 
 env:
   AWS_REGION: eu-west-2
-  SELENIUM_BASE: selenium/standalone-chromium:132.0
+  SELENIUM_BASE: selenium/standalone-chromium:148.0
 
 on:
   push:

--- a/.github/workflows/build-and-push-tests-dev.yaml
+++ b/.github/workflows/build-and-push-tests-dev.yaml
@@ -4,7 +4,7 @@ env:
   AWS_REGION: eu-west-2
   DEV_GHA_DEPLOYER_ROLE: arn:aws:iam::653994557586:role/dev-auth-deploy-pipeline-GitHubActionsRole-QrtGginNnjDD
   DEV_ACCEPTANCE_ECR_REPO: acceptance-test-dev-testrunnerimagerepository-yh8assqv55do
-  SELENIUM_BASE_CHROMIUM: selenium/standalone-chromium:132.0
+  SELENIUM_BASE_CHROMIUM: selenium/standalone-chromium:148.0
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build-and-push-tests.yaml
+++ b/.github/workflows/build-and-push-tests.yaml
@@ -2,7 +2,7 @@ name: Build and Push Acceptance Tests
 
 env:
   AWS_REGION: eu-west-2
-  SELENIUM_BASE: selenium/standalone-chromium:132.0
+  SELENIUM_BASE: selenium/standalone-chromium:148.0
 
 #Role to Assume is  dev-auth-deploy-pipeline githubaction Role
 #ECR repo is acceptance test ECR repo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG SELENIUM_BASE=selenium/standalone-chromium:132.0
+ARG SELENIUM_BASE=selenium/standalone-chromium:148.0
 FROM gradle:8-jdk17 AS builder
 
 WORKDIR /test

--- a/acceptance-tests/src/test/java/uk/gov/di/test/utils/Driver.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/utils/Driver.java
@@ -3,6 +3,8 @@ package uk.gov.di.test.utils;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 
+import java.io.File;
+
 public class Driver {
     protected static final Boolean SELENIUM_HEADLESS =
             Boolean.valueOf(Environment.getOrThrow("SELENIUM_HEADLESS"));
@@ -18,6 +20,10 @@ public class Driver {
         if (driverPool.get() == null)
             synchronized (Driver.class) {
                 ChromeOptions chromeOptions = buildChromeOptions();
+                File chromedriver = new File("/usr/bin/chromedriver");
+                if (chromedriver.exists()) {
+                    System.setProperty("webdriver.chrome.driver", chromedriver.getAbsolutePath());
+                }
                 System.setProperty("webdriver.chrome.whitelistedIps", "");
                 driverPool.set(new ChromeDriver(chromeOptions));
                 driverPool.get().manage().deleteAllCookies();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,7 @@ version: '3.8'
 
 services:
   selenium-chrome:
-    image: selenium/standalone-chrome@sha256:36784cc22ea01886ac226146be343afe7d984d9fc69436e52c2c0f8fd0dc0f55
-    #USE THESE VALUES IF YOU HAVE A MAC M1/M2/M3 (ARM) chip
-    #image: seleniarm/standalone-chromium:latest
+    image: selenium/standalone-chromium@sha256:8c5a8629c96104c0d73df94c6437af9ab9059c4e16aa32e35b330b7d77defe0b
     ports:
       - 4444:4444
     networks:


### PR DESCRIPTION
## What

### The problem

We recently bumped the Selenium library from 4.35 to 4.44. This broke the `rundocker.sh` script.

The way Selenium pulls the driver changed as of 4.37 (we recently upgraded from 4.35 to 4.44).

Previously, it would try to use the driver that's bundled with Selenium and fall back to what's installed on PATH if that wasn't available.

But since the version bump, it strictly uses the bundled version. If a bundled version doesn't exist for your OS (which it doesn't when running inside of a Linux/ARM Docker container), it fails.

That is, unless, you specify a specific chrome driver file path via the `webdriver.chrome.driver` property.

### The solution

Now, the Driver.java file will attempt to find the `/usr/bin/chromedriver` file (this will exist when running within our Docker containers). If the file exists, it will use it as its driver. If it doesn't exist (e.g. if you're running a test direct from IntelliJ), it will fallback to using the default Selenium Manager (so in the case of an IntelliJ run, it would use your installed Chrome).

## How to review

1. Code Review
2. Try running `./rundocker.sh dev-ui` locally