### PR TITLE
AUT-5470: Disable JavaScript and test passkey fallback journey

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
@@ -11,6 +11,7 @@ import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import uk.gov.di.test.pages.BasePage;
 import uk.gov.di.test.pages.CreateOrSignInPage;
@@ -43,6 +44,13 @@ public class CommonStepDef extends BasePage {
     }
 
     String idToken;
+
+    @Given("JavaScript is disabled")
+    public void javaScriptIsDisabled() {
+        ChromeDriver driver = Driver.get();
+        driver.executeCdpCommand(
+                "Emulation.setScriptExecutionDisabled", java.util.Map.of("value", true));
+    }
 
     @Then("the user email is not blocked to proceed with account creation")
     public void emailNotBlocked() {

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/passkeys.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/passkeys.feature
@@ -134,3 +134,13 @@ Feature: Passkeys
     Given the user will succeed verification
     When the user selects radio button "Try signing in with your passkey again"
     Then the user is returned to the service
+
+  @PasskeyUsageEnabled
+  Scenario: Existing user with a passkey is routed to Enter Password if JavaScript is disabled
+    Given a user exists with a passkey
+    And JavaScript is disabled
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email address" page
+    When the user enters their email address
+    Then the user is taken to the "Enter your password" page


### PR DESCRIPTION
## What

Adds a new step definition, `Given JavaScript is disabled`, which allows you to disable JavaScript in the journey.

Used that new step def in a test where the user has a passkey but has JS disabled, to ensure they're routed down the password journey.

## How to review

1. Code Review