### PR TITLE
AUT-5529: Add test for suppression of passkey prompt based on new acc…

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/services/UserLifecycleService.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/services/UserLifecycleService.java
@@ -141,7 +141,8 @@ public class UserLifecycleService {
                 .withPublicSubjectID(UUID.randomUUID().toString())
                 .withSubjectID(UUID.randomUUID().toString())
                 .withSalt(Crypto.generateSalt())
-                .withTermsAndConditions(buildTermsAndConditions());
+                .withTermsAndConditions(buildTermsAndConditions())
+                .withCreated(CREATION_DATE_OLDER_THAN_2_HOURS);
     }
 
     public UserProfile buildNewMigratedUserProfile() {

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/UserLifecycleStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/UserLifecycleStepDef.java
@@ -12,6 +12,7 @@ import uk.gov.di.test.services.UserLifecycleService;
 import uk.gov.di.test.services.VirtualAuthenticatorLifecycleService;
 
 import static uk.gov.di.test.services.UserLifecycleService.generateValidPassword;
+import static uk.gov.di.test.utils.Constants.CREATION_DATE_NEWER_THAN_2_HOURS;
 import static uk.gov.di.test.utils.Constants.TOP_100K_PASSWORD;
 
 public class UserLifecycleStepDef {
@@ -85,6 +86,16 @@ public class UserLifecycleStepDef {
                         world.userProfile, world.getUserPassword());
     }
 
+    @Given("a user with a new account exists")
+    public void aUserExistsWithANewAccount() {
+        aUserDoesNotYetExist();
+        world.userProfile.setCreated(CREATION_DATE_NEWER_THAN_2_HOURS);
+        userLifecycleService.putUserProfileToDynamodb(world.userProfile);
+        world.userCredentials =
+                userLifecycleService.buildNewUserCredentialsAndPutToDynamodb(
+                        world.userProfile, world.getUserPassword());
+    }
+
     @ParameterType("SMS|App|no")
     public String mfaMethod(String mfaMethodType) {
         return mfaMethodType;
@@ -96,6 +107,16 @@ public class UserLifecycleStepDef {
     @Given("a user with no passkey and {mfaMethod} MFA exists")
     public void aUserExists(String mfaMethod) {
         aUserExists();
+        setMfaMethodOnUser(mfaMethod);
+    }
+
+    @Given("a user with a new account and no passkey and {mfaMethod} MFA exists")
+    public void aUserExistsWithANewAccount(String mfaMethod) {
+        aUserExistsWithANewAccount();
+        setMfaMethodOnUser(mfaMethod);
+    }
+
+    private void setMfaMethodOnUser(String mfaMethod) {
         switch (mfaMethod) {
             case "no":
                 break;

--- a/acceptance-tests/src/test/java/uk/gov/di/test/utils/Constants.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/utils/Constants.java
@@ -1,5 +1,8 @@
 package uk.gov.di.test.utils;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
 public final class Constants {
 
     public static final String INVALID_EMAIL = "joe.bloggs";
@@ -28,6 +31,10 @@ public final class Constants {
             "+447700900000";
     public static final String UK_MOBILE_PHONE_NUMBER_INCORRECT_FORMAT = "077009000000000";
     public static final String UK_MOBILE_PHONE_NUMBER_NON_DIGIT_CHARS = "0770090*a45";
+    public static final String CREATION_DATE_OLDER_THAN_2_HOURS =
+            LocalDateTime.now(ZoneOffset.UTC).minusDays(2).toString();
+    public static final String CREATION_DATE_NEWER_THAN_2_HOURS =
+            LocalDateTime.now(ZoneOffset.UTC).minusMinutes(20).toString();
 
     public static final String DEFAULT_TIMESTAMP = "1970-01-01T00:00:00.000000";
 

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/passkeys.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/passkeys.feature
@@ -16,6 +16,18 @@ Feature: Passkeys
     When the user chooses to skip passkey registration
     Then the user is returned to the service
 
+  Scenario: Existing user with a new account and no passkey is not prompted to setup a passkey
+    Given a user with a new account and no passkey and SMS MFA exists
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
+    When the user enters their email address
+    Then the user is taken to the "Enter your password" page
+    When the user enters their password
+    Then the user is taken to the "Check your phone" page
+    When the user enters the six digit security code from their phone
+    Then the user is returned to the service
+
   Scenario: Existing user without a passkey not on latest terms and conditions can log in and skip passkey creation successfully
     Given a user with no passkey and SMS MFA exists
     And the user has not yet accepted the latest terms and conditions


### PR DESCRIPTION
The behaviour for whether a user will be prompted to set up a passkey or not depends on several factors, including whether they have javascript on or not etc, and now also depends on how old their account is.

If it's older than 2 hours, they can be prompted (as long as the other criteria are also met) but if it was created lessthan two hours ago they should not be prompted.

This sets up a new test to check this behaviour, and also sets a created at date of more than two hours ago on the user for all the existing tests - this ensures that if an existing test checks that a user is prompted to set up a passkey, this still all works.