### PR TITLE
BAU: Authenticator thread pooling

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/BasePage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/BasePage.java
@@ -49,15 +49,15 @@ public class BasePage {
     protected void waitForPageLoad(String titleContains) {
         Instant start = Instant.now();
         try {
-            new WebDriverWait(Driver.get(), DEFAULT_PAGE_LOAD_WAIT_TIME)
+            new WebDriverWait(Driver.getOrCreate(), DEFAULT_PAGE_LOAD_WAIT_TIME)
                     .until(ExpectedConditions.titleContains(titleContains));
         } catch (WebDriverException e) {
             throw new SessionContextExceptions.WaitForPageLoadException(
                     titleContains,
-                    Driver.get().getCurrentUrl(),
-                    Driver.get().getTitle(),
+                    Driver.getOrCreate().getCurrentUrl(),
+                    Driver.getOrCreate().getTitle(),
                     start,
-                    new OneLoginSession(Driver.get().manage().getCookies()),
+                    new OneLoginSession(Driver.getOrCreate().manage().getCookies()),
                     e);
         }
         waitForReadyStateComplete();
@@ -67,20 +67,20 @@ public class BasePage {
         waitForPageLoad(page.getShortTitle());
         assertEquals(
                 page.getRoute(),
-                URI.create(Objects.requireNonNull(Driver.get().getCurrentUrl())).getPath());
-        assertEquals(page.getFullTitle(), Driver.get().getTitle());
+                URI.create(Objects.requireNonNull(Driver.getOrCreate().getCurrentUrl())).getPath());
+        assertEquals(page.getFullTitle(), Driver.getOrCreate().getTitle());
     }
 
     protected WebElement findElement(By selector) {
         waitForReadyStateComplete();
         try {
-            return Driver.get().findElement(selector);
+            return Driver.getOrCreate().findElement(selector);
         } catch (WebDriverException e) {
             throw new SessionContextExceptions.FindElementException(
                     selector.toString(),
-                    Driver.get().getCurrentUrl(),
-                    Driver.get().getTitle(),
-                    new OneLoginSession(Driver.get().manage().getCookies()),
+                    Driver.getOrCreate().getCurrentUrl(),
+                    Driver.getOrCreate().getTitle(),
+                    new OneLoginSession(Driver.getOrCreate().manage().getCookies()),
                     e);
         }
     }
@@ -106,10 +106,13 @@ public class BasePage {
     public void switchDefaultTimeout(String status) {
         switch (status.toLowerCase()) {
             case "on":
-                Driver.get().manage().timeouts().implicitlyWait(DEFAULT_PAGE_LOAD_WAIT_TIME);
+                Driver.getOrCreate()
+                        .manage()
+                        .timeouts()
+                        .implicitlyWait(DEFAULT_PAGE_LOAD_WAIT_TIME);
                 break;
             case "off":
-                Driver.get().manage().timeouts().implicitlyWait(NO_PAGE_LOAD_WAIT_TIME);
+                Driver.getOrCreate().manage().timeouts().implicitlyWait(NO_PAGE_LOAD_WAIT_TIME);
                 break;
             default:
                 throw new RuntimeException("Invalid status: " + status);
@@ -119,7 +122,7 @@ public class BasePage {
     protected boolean isLinkTextDisplayedImmediately(String linkText) {
         switchDefaultTimeout("off");
         List<WebElement> elements =
-                Driver.get()
+                Driver.getOrCreate()
                         .findElements(
                                 By.xpath("//*[text()[normalize-space() = '" + linkText + "']]"));
         switchDefaultTimeout("on");
@@ -127,7 +130,7 @@ public class BasePage {
     }
 
     public void waitForThisErrorMessage(String expectedMessage) {
-        new WebDriverWait(Driver.get(), DEFAULT_PAGE_LOAD_WAIT_TIME)
+        new WebDriverWait(Driver.getOrCreate(), DEFAULT_PAGE_LOAD_WAIT_TIME)
                 .until(
                         ExpectedConditions.visibilityOf(
                                 findElement(
@@ -135,7 +138,7 @@ public class BasePage {
     }
 
     public void waitForThisText(String expectedText) {
-        new WebDriverWait(Driver.get(), DEFAULT_PAGE_LOAD_WAIT_TIME)
+        new WebDriverWait(Driver.getOrCreate(), DEFAULT_PAGE_LOAD_WAIT_TIME)
                 .until(
                         ExpectedConditions.visibilityOf(
                                 findElement(
@@ -170,14 +173,14 @@ public class BasePage {
     }
 
     public void switchToTabByIndex(Integer idx) {
-        ArrayList<String> tabs = new ArrayList<>(Driver.get().getWindowHandles());
-        Driver.get().switchTo().window(tabs.get(idx));
+        ArrayList<String> tabs = new ArrayList<>(Driver.getOrCreate().getWindowHandles());
+        Driver.getOrCreate().switchTo().window(tabs.get(idx));
     }
 
     public void switchToTabWithTitleContaining(String titleToSwitchTo) {
-        Set<String> allTabs = Driver.get().getWindowHandles();
+        Set<String> allTabs = Driver.getOrCreate().getWindowHandles();
         for (String tab : allTabs) {
-            String title = Driver.get().switchTo().window(tab).getTitle();
+            String title = Driver.getOrCreate().switchTo().window(tab).getTitle();
             assert title != null;
             if (title.contains(titleToSwitchTo)) {
                 break;
@@ -186,7 +189,7 @@ public class BasePage {
     }
 
     protected void closeActiveTab() {
-        Driver.get().close();
+        Driver.getOrCreate().close();
     }
 
     public void enterCorrectAuthAppCodeAndContinue(String authAppSecretKey) {
@@ -196,23 +199,23 @@ public class BasePage {
     }
 
     public void setAnalyticsCookieTo(Boolean state) {
-        Driver.get()
+        Driver.getOrCreate()
                 .manage()
                 .addCookie(new Cookie("cookies_preferences_set", "{\"analytics\":" + state + "}"));
     }
 
     public void waitUntilElementClickable(By by) {
-        new WebDriverWait(Driver.get(), DEFAULT_PAGE_LOAD_WAIT_TIME)
+        new WebDriverWait(Driver.getOrCreate(), DEFAULT_PAGE_LOAD_WAIT_TIME)
                 .until(ExpectedConditions.elementToBeClickable(findElement(by)));
     }
 
     public void waitUntilElementClickable(WebElement element) {
-        new WebDriverWait(Driver.get(), DEFAULT_PAGE_LOAD_WAIT_TIME)
+        new WebDriverWait(Driver.getOrCreate(), DEFAULT_PAGE_LOAD_WAIT_TIME)
                 .until(ExpectedConditions.elementToBeClickable(element));
     }
 
     public static void waitForReadyStateComplete() {
-        new WebDriverWait(Driver.get(), DEFAULT_PAGE_LOAD_WAIT_TIME)
+        new WebDriverWait(Driver.getOrCreate(), DEFAULT_PAGE_LOAD_WAIT_TIME)
                 .until(
                         (ExpectedCondition<Boolean>)
                                 wd ->

--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/BasePage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/BasePage.java
@@ -37,7 +37,6 @@ public class BasePage {
     protected static final Duration DEFAULT_PAGE_LOAD_WAIT_TIME = Duration.ofSeconds(20);
     protected static final Duration NO_PAGE_LOAD_WAIT_TIME = Duration.ofSeconds(0);
 
-    protected static WebDriver driver;
     protected static Scenario scenario;
 
     public void waitForPage() {

--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/CannotUseEmailAddressPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/CannotUseEmailAddressPage.java
@@ -16,22 +16,22 @@ public class CannotUseEmailAddressPage extends BasePage {
 
     @Override
     public void waitForPage() {
-        WebDriverWait wait = new WebDriverWait(Driver.get(), DEFAULT_PAGE_LOAD_WAIT_TIME);
+        WebDriverWait wait = new WebDriverWait(Driver.getOrCreate(), DEFAULT_PAGE_LOAD_WAIT_TIME);
         wait.until(ExpectedConditions.urlContains(PATH));
         wait.until(ExpectedConditions.visibilityOfElementLocated(h1));
     }
 
     public String heading() {
-        return Driver.get().findElement(h1).getText();
+        return Driver.getOrCreate().findElement(h1).getText();
     }
 
     public String screenText() {
-        WebElement el = Driver.get().findElement(bodyText);
+        WebElement el = Driver.getOrCreate().findElement(bodyText);
         return el.getText();
     }
 
     public void clickTryAnotherEmail() {
-        WebDriverWait wait = new WebDriverWait(Driver.get(), DEFAULT_PAGE_LOAD_WAIT_TIME);
+        WebDriverWait wait = new WebDriverWait(Driver.getOrCreate(), DEFAULT_PAGE_LOAD_WAIT_TIME);
         wait.until(ExpectedConditions.elementToBeClickable(tryAnotherEmailLink)).click();
     }
 

--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/CheckYourPhonePage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/CheckYourPhonePage.java
@@ -27,15 +27,15 @@ public class CheckYourPhonePage extends BasePage {
     }
 
     public void clickProblemsWithTheCodeLink() {
-        Driver.get().findElement(problemsWithTheCodeLink).click();
+        Driver.getOrCreate().findElement(problemsWithTheCodeLink).click();
     }
 
     public void clickChangeHowYouGetSecurityCodesLink() {
-        Driver.get().findElement(changeHowYouGetSecurityCodesLink).click();
+        Driver.getOrCreate().findElement(changeHowYouGetSecurityCodesLink).click();
     }
 
     public void clickSendTheCodeAgainLink() {
-        Driver.get().findElement(sendTheCodeAgainLink).click();
+        Driver.getOrCreate().findElement(sendTheCodeAgainLink).click();
     }
 
     public void enterIncorrectPhoneSecurityCodeNumberOfTimes(Integer numberOfTimes) {

--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/ChooseHowToGetSecurityCodesPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/ChooseHowToGetSecurityCodesPage.java
@@ -10,10 +10,10 @@ public class ChooseHowToGetSecurityCodesPage extends BasePage {
     public void selectAuthMethodAndContinue(String method) {
         switch (method.toLowerCase()) {
             case "text message":
-                Driver.get().findElement(textMessageRadioButton).click();
+                Driver.getOrCreate().findElement(textMessageRadioButton).click();
                 break;
             case "auth app":
-                Driver.get().findElement(authAppRadioButton).click();
+                Driver.getOrCreate().findElement(authAppRadioButton).click();
                 break;
             default:
                 throw new RuntimeException("Invalid method type: " + method);
@@ -22,10 +22,10 @@ public class ChooseHowToGetSecurityCodesPage extends BasePage {
     }
 
     public Boolean getTextMessageRadioButtonStatus() {
-        return Driver.get().findElement(textMessageRadioButton).isSelected();
+        return Driver.getOrCreate().findElement(textMessageRadioButton).isSelected();
     }
 
     public Boolean getAuthAppRadioButtonStatus() {
-        return Driver.get().findElement(authAppRadioButton).isSelected();
+        return Driver.getOrCreate().findElement(authAppRadioButton).isSelected();
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/CreateOrSignInPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/CreateOrSignInPage.java
@@ -11,20 +11,20 @@ public class CreateOrSignInPage extends BasePage {
     By linkToSwitchToEnglish = By.xpath("//a[@href='?lng=en']");
 
     public void clickCreateAGovUkOneLoginButton() {
-        Driver.get().findElement(createAGovUkOneLogin).click();
+        Driver.getOrCreate().findElement(createAGovUkOneLogin).click();
     }
 
     public void clickSignInButton() {
-        Driver.get().findElement(signInButton).click();
+        Driver.getOrCreate().findElement(signInButton).click();
     }
 
     public void switchLanguageTo(String language) {
         switch (language.toLowerCase()) {
             case "welsh":
-                Driver.get().findElement(linkToSwitchToWelsh).click();
+                Driver.getOrCreate().findElement(linkToSwitchToWelsh).click();
                 break;
             case "english":
-                Driver.get().findElement(linkToSwitchToEnglish).click();
+                Driver.getOrCreate().findElement(linkToSwitchToEnglish).click();
                 break;
             default:
                 throw new RuntimeException("Invalid language: " + language);

--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/CreatePasskeysPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/CreatePasskeysPage.java
@@ -14,21 +14,21 @@ public class CreatePasskeysPage extends BasePage {
 
     @Override
     public void waitForPage() {
-        WebDriverWait wait = new WebDriverWait(Driver.get(), DEFAULT_PAGE_LOAD_WAIT_TIME);
+        WebDriverWait wait = new WebDriverWait(Driver.getOrCreate(), DEFAULT_PAGE_LOAD_WAIT_TIME);
         wait.until(ExpectedConditions.urlContains(PATH));
         wait.until(ExpectedConditions.visibilityOfElementLocated(h1));
     }
 
     public void clickSkipButton() {
-        Driver.get().findElement(skipButton).click();
+        Driver.getOrCreate().findElement(skipButton).click();
     }
 
     public void dismissIfPresent() {
         // Prevents a race condition after MFA code submission. In non-MFA flows this is a no-op.
-        new WebDriverWait(Driver.get(), DEFAULT_PAGE_LOAD_WAIT_TIME)
+        new WebDriverWait(Driver.getOrCreate(), DEFAULT_PAGE_LOAD_WAIT_TIME)
                 .until(ExpectedConditions.not(ExpectedConditions.urlContains("/enter-code")));
         waitForReadyStateComplete();
-        if (Driver.get().getCurrentUrl().contains(PATH)) {
+        if (Driver.getOrCreate().getCurrentUrl().contains(PATH)) {
             clickSkipButton();
         }
     }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/DocAppPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/DocAppPage.java
@@ -16,26 +16,26 @@ public class DocAppPage extends BasePage {
     By idToken = By.id("user-info-phone-number");
 
     public void continueButtonClick() {
-        Driver.get().findElement(continueButton).click();
+        Driver.getOrCreate().findElement(continueButton).click();
     }
 
     public void accountLinkClick() {
-        Driver.get().findElement(myAccountLink).click();
+        Driver.getOrCreate().findElement(myAccountLink).click();
     }
 
     public void enterPayLoad(String jsonPayLoad) {
-        Driver.get().findElement(payloadInputField).sendKeys(jsonPayLoad);
+        Driver.getOrCreate().findElement(payloadInputField).sendKeys(jsonPayLoad);
     }
 
     public void clickSubmitButton() {
-        Driver.get().findElement(submitButton).click();
+        Driver.getOrCreate().findElement(submitButton).click();
     }
 
     public Boolean docAppCredentialsDisplayed() {
-        return Driver.get().findElement(docAppCredentials).isDisplayed();
+        return Driver.getOrCreate().findElement(docAppCredentials).isDisplayed();
     }
 
     public Boolean idTokenDisplayed() {
-        return Driver.get().findElement(idToken).isDisplayed();
+        return Driver.getOrCreate().findElement(idToken).isDisplayed();
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/EnterYourEmailAddressPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/EnterYourEmailAddressPage.java
@@ -18,10 +18,10 @@ public class EnterYourEmailAddressPage extends BasePage {
     }
 
     public String continueButtonText() {
-        return Driver.get().findElement(continueButton).getText();
+        return Driver.getOrCreate().findElement(continueButton).getText();
     }
 
     public String backButtonText() {
-        return Driver.get().findElement(backButton).getText();
+        return Driver.getOrCreate().findElement(backButton).getText();
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/EnterYourMobilePhoneNumberPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/EnterYourMobilePhoneNumberPage.java
@@ -11,11 +11,11 @@ public class EnterYourMobilePhoneNumberPage extends BasePage {
     By ukPhoneNumberField = By.id("phoneNumber");
 
     public boolean isInternationalMobileNumberFieldDisplayed() {
-        return Driver.get().findElement(internationalPhoneNumberField).isDisplayed();
+        return Driver.getOrCreate().findElement(internationalPhoneNumberField).isDisplayed();
     }
 
     public void tickIDoNotHaveUkMobileNumber() {
-        Driver.get().findElement(iDoNotHaveUkMobilePhoneNumberCheckbox).click();
+        Driver.getOrCreate().findElement(iDoNotHaveUkMobilePhoneNumberCheckbox).click();
     }
 
     public void enterInternationalMobilePhoneNumberAndContinue(

--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/EnterYourPasswordPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/EnterYourPasswordPage.java
@@ -24,7 +24,7 @@ public class EnterYourPasswordPage extends BasePage {
     }
 
     public void clickForgottenPasswordLink() {
-        Driver.get().findElement(forgottenPasswordLink).click();
+        Driver.getOrCreate().findElement(forgottenPasswordLink).click();
     }
 
     public void enterPasswordAndContinue(String pw) {

--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/FinishCreatingYourAccountPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/FinishCreatingYourAccountPage.java
@@ -10,10 +10,10 @@ public class FinishCreatingYourAccountPage extends BasePage {
     public void selectAuthMethodAndContinue(String method) {
         switch (method.toLowerCase()) {
             case "text message":
-                Driver.get().findElement(textMessageRadioButton).click();
+                Driver.getOrCreate().findElement(textMessageRadioButton).click();
                 break;
             case "auth app":
-                Driver.get().findElement(authAppRadioButton).click();
+                Driver.getOrCreate().findElement(authAppRadioButton).click();
                 break;
             default:
                 throw new RuntimeException("Invalid method type: " + method);

--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/GetSecurityCodePage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/GetSecurityCodePage.java
@@ -7,7 +7,7 @@ public class GetSecurityCodePage extends BasePage {
     By getSecurityCodeButton = By.xpath("//button[contains(text(), 'Get security code')]");
 
     public void pressGetSecurityCodeButton() {
-        Driver.get().findElement(getSecurityCodeButton).click();
+        Driver.getOrCreate().findElement(getSecurityCodeButton).click();
     }
 
     @Override

--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/LegacyStubStartPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/LegacyStubStartPage.java
@@ -36,7 +36,7 @@ public class LegacyStubStartPage extends StubStartPage {
             if (ignoredOptions.contains(id)) {
                 continue;
             }
-            Driver.get().findElement(By.id(id)).click();
+            Driver.getOrCreate().findElement(By.id(id)).click();
         }
     }
 

--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/LegacyStubUserInfoPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/LegacyStubUserInfoPage.java
@@ -11,18 +11,18 @@ public class LegacyStubUserInfoPage extends StubUserInfoPage {
 
     @Override
     public String getIdToken() {
-        return Driver.get().findElement(idTokenField).getText();
+        return Driver.getOrCreate().findElement(idTokenField).getText();
     }
 
     @Override
     public String getAccessToken() {
-        return Driver.get().findElement(accessTokenField).getText();
+        return Driver.getOrCreate().findElement(accessTokenField).getText();
     }
 
     @Override
     public void logoutOfAccount() {
-        Driver.get().findElement(logoutButton).click();
-        Driver.get().manage().deleteAllCookies();
+        Driver.getOrCreate().findElement(logoutButton).click();
+        Driver.getOrCreate().manage().deleteAllCookies();
     }
 
     @Override

--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/LockoutPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/LockoutPage.java
@@ -8,6 +8,6 @@ public class LockoutPage extends BasePage {
     By lockoutScreenText = By.cssSelector("#main-content .govuk-grid-column-two-thirds");
 
     public String getLockoutScreenText() {
-        return Driver.get().findElement(lockoutScreenText).getText();
+        return Driver.getOrCreate().findElement(lockoutScreenText).getText();
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/NoGovUkOneLoginFoundPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/NoGovUkOneLoginFoundPage.java
@@ -7,6 +7,6 @@ public class NoGovUkOneLoginFoundPage extends BasePage {
     By createAccountButton = By.xpath("//button[contains(text(), 'Create a GOV.UK One Login')]");
 
     public void clickCreateGovUkOneLoginButton() {
-        Driver.get().findElement(createAccountButton).click();
+        Driver.getOrCreate().findElement(createAccountButton).click();
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/OrchestrationStubStartPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/OrchestrationStubStartPage.java
@@ -55,7 +55,7 @@ public class OrchestrationStubStartPage extends StubStartPage {
                 default:
                     break;
             }
-            Driver.get().findElement(By.id(id)).click();
+            Driver.getOrCreate().findElement(By.id(id)).click();
         }
     }
 

--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/OrchestrationStubUserInfoPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/OrchestrationStubUserInfoPage.java
@@ -14,25 +14,25 @@ public class OrchestrationStubUserInfoPage extends StubUserInfoPage {
     @Override
     public String getIdToken() {
         try {
-            String jsonText = Driver.get().findElement(userInfoField).getText();
+            String jsonText = Driver.getOrCreate().findElement(userInfoField).getText();
             ObjectMapper mapper = new ObjectMapper();
             JsonNode root = mapper.readTree(jsonText);
             return root.get("rp_pairwise_id").asText();
         } catch (Exception e) {
-            System.out.println("[DEBUG] Current URL: " + Driver.get().getCurrentUrl());
-            System.out.println("[DEBUG] Page title: " + Driver.get().getTitle());
+            System.out.println("[DEBUG] Current URL: " + Driver.getOrCreate().getCurrentUrl());
+            System.out.println("[DEBUG] Page title: " + Driver.getOrCreate().getTitle());
             throw new RuntimeException("Failed to extract rp_pairwise_id from user info JSON", e);
         }
     }
 
     @Override
     public String getAccessToken() {
-        return Driver.get().findElement(accessTokenField).getText();
+        return Driver.getOrCreate().findElement(accessTokenField).getText();
     }
 
     @Override
     public void logoutOfAccount() {
-        Driver.get().manage().deleteAllCookies();
+        Driver.getOrCreate().manage().deleteAllCookies();
     }
 
     @Override

--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/SetUpAnAuthenticatorAppPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/SetUpAnAuthenticatorAppPage.java
@@ -15,13 +15,15 @@ public class SetUpAnAuthenticatorAppPage extends BasePage {
     By authAppCodeField = By.id("code");
 
     public void iCannotScanQrCodeClick() {
-        Driver.get().findElement(iCannotScanTheQrCode).click();
+        Driver.getOrCreate().findElement(iCannotScanTheQrCode).click();
     }
 
     public String getSecretFieldText() {
-        new WebDriverWait(Driver.get(), DEFAULT_PAGE_LOAD_WAIT_TIME)
-                .until(ExpectedConditions.visibilityOf(Driver.get().findElement(secretKeyField)));
-        List<WebElement> secretKeyComponents = Driver.get().findElements(secretKeyBlocks);
+        new WebDriverWait(Driver.getOrCreate(), DEFAULT_PAGE_LOAD_WAIT_TIME)
+                .until(
+                        ExpectedConditions.visibilityOf(
+                                Driver.getOrCreate().findElement(secretKeyField)));
+        List<WebElement> secretKeyComponents = Driver.getOrCreate().findElements(secretKeyBlocks);
         StringBuilder secretKeyText = new StringBuilder();
         for (int i = 1; i < secretKeyComponents.size(); i++) {
             secretKeyText.append(secretKeyComponents.get(i).getText());

--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/StubStartPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/StubStartPage.java
@@ -16,7 +16,7 @@ public abstract class StubStartPage extends BasePage {
 
     public void goToRpStub() {
         System.out.println("Go to RP stub page: " + RP_URL);
-        Driver.get().get(RP_URL);
+        Driver.getOrCreate().get(RP_URL);
         waitForStubToLoad();
     }
 
@@ -106,8 +106,8 @@ public abstract class StubStartPage extends BasePage {
     }
 
     protected void enterReauthIdToken(String token) {
-        Driver.get().findElement(getReauthIdField()).clear();
-        Driver.get().findElement(getReauthIdField()).sendKeys(token);
+        Driver.getOrCreate().findElement(getReauthIdField()).clear();
+        Driver.getOrCreate().findElement(getReauthIdField()).sendKeys(token);
     }
 
     public static StubType getStubType() {

--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/SupportPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/SupportPage.java
@@ -13,17 +13,17 @@ public class SupportPage extends BasePage {
             By.cssSelector("div[class='govuk-details__text'] p[class='govuk-body']");
 
     public void clickSupportLink() {
-        Driver.get().findElement(supportLink).click();
+        Driver.getOrCreate().findElement(supportLink).click();
     }
 
     public void selectSupportRadioButtonByLabelText(String option) {
-        Driver.get()
+        Driver.getOrCreate()
                 .findElement(By.xpath("//div[label[contains(text(), '" + option + "')]]/input"))
                 .click();
     }
 
     public void enterMoreDetails(String details) {
-        Driver.get().findElement(moreDetailsField).sendKeys(details);
+        Driver.getOrCreate().findElement(moreDetailsField).sendKeys(details);
     }
 
     public void canWeReplyViaEmail(String option) {
@@ -35,7 +35,7 @@ public class SupportPage extends BasePage {
     }
 
     public boolean isSuccessMessageDisplayed() {
-        return Driver.get().findElement(successMessage).isDisplayed();
+        return Driver.getOrCreate().findElement(successMessage).isDisplayed();
     }
 
     public void selectRadioButtonAndProceed(String radioButtonLabel) {
@@ -52,15 +52,15 @@ public class SupportPage extends BasePage {
     }
 
     public String getLinkText() {
-        return Driver.get().findElement(mfaSupportLinkText).getText();
+        return Driver.getOrCreate().findElement(mfaSupportLinkText).getText();
     }
 
     public String getLinkAppText() {
-        return Driver.get().findElement(mfaSupportLinkAppText).getText();
+        return Driver.getOrCreate().findElement(mfaSupportLinkAppText).getText();
     }
 
     public void selectRadioButtonForPhoneAndProceed(String text, String mobilenumber) {
-        Driver.get()
+        Driver.getOrCreate()
                 .findElement(
                         By.xpath(
                                 "//label[contains(., '"

--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/TermsAndConditionsPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/TermsAndConditionsPage.java
@@ -8,6 +8,6 @@ public class TermsAndConditionsPage extends BasePage {
     By agreeAndContinueButton = By.name("termsAndConditionsResult");
 
     public void pressAgreeAndContinueButton() {
-        Driver.get().findElement(agreeAndContinueButton).click();
+        Driver.getOrCreate().findElement(agreeAndContinueButton).click();
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/YouAskedToResendTheSecurityCodeTooManyTimesPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/YouAskedToResendTheSecurityCodeTooManyTimesPage.java
@@ -8,6 +8,6 @@ public class YouAskedToResendTheSecurityCodeTooManyTimesPage extends BasePage {
     By getANewCodeLink = By.xpath("//*[contains(text(), 'get a new code')]");
 
     public void clickGetANewCodeLink() {
-        Driver.get().findElement(getANewCodeLink).click();
+        Driver.getOrCreate().findElement(getANewCodeLink).click();
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/YouveChangedHowYouGetSecurityCodesPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/YouveChangedHowYouGetSecurityCodesPage.java
@@ -8,6 +8,6 @@ public class YouveChangedHowYouGetSecurityCodesPage extends BasePage {
     By securityCodeConfirmationText = By.cssSelector("form .govuk-body");
 
     public String getSecurityCodeMessageText() {
-        return Driver.get().findElement(securityCodeConfirmationText).getText();
+        return Driver.getOrCreate().findElement(securityCodeConfirmationText).getText();
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/services/VirtualAuthenticatorLifecycleService.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/services/VirtualAuthenticatorLifecycleService.java
@@ -44,10 +44,9 @@ public class VirtualAuthenticatorLifecycleService {
         var authenticator = authenticatorPool.get();
         if (authenticator == null) return;
 
-        var driver = Driver.getDriver();
-        if (driver != null) {
-            driver.removeVirtualAuthenticator(authenticator);
-        }
+        Driver.get()
+                .ifPresent(chromeDriver -> chromeDriver.removeVirtualAuthenticator(authenticator));
+
         authenticatorPool.remove();
     }
 

--- a/acceptance-tests/src/test/java/uk/gov/di/test/services/VirtualAuthenticatorLifecycleService.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/services/VirtualAuthenticatorLifecycleService.java
@@ -29,7 +29,7 @@ public class VirtualAuthenticatorLifecycleService {
                     "Cannot create a second virtual authenticator while one is already attached");
         }
 
-        var driver = Driver.get();
+        var driver = Driver.getOrCreate();
 
         VirtualAuthenticatorOptions options =
                 new VirtualAuthenticatorOptions()

--- a/acceptance-tests/src/test/java/uk/gov/di/test/services/VirtualAuthenticatorLifecycleService.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/services/VirtualAuthenticatorLifecycleService.java
@@ -7,7 +7,8 @@ import uk.gov.di.test.utils.Driver;
 
 public class VirtualAuthenticatorLifecycleService {
     private static volatile VirtualAuthenticatorLifecycleService instance;
-    private VirtualAuthenticator authenticator;
+    private static final InheritableThreadLocal<VirtualAuthenticator> authenticatorPool =
+            new InheritableThreadLocal<>();
 
     private VirtualAuthenticatorLifecycleService() {}
 
@@ -23,7 +24,7 @@ public class VirtualAuthenticatorLifecycleService {
     }
 
     public void createVirtualAuthenticator() {
-        if (authenticator != null) {
+        if (authenticatorPool.get() != null) {
             throw new UnsupportedOperationException(
                     "Cannot create a second virtual authenticator while one is already attached");
         }
@@ -36,26 +37,29 @@ public class VirtualAuthenticatorLifecycleService {
                         .setHasUserVerification(true)
                         .setIsUserVerified(true);
 
-        authenticator = driver.addVirtualAuthenticator(options);
+        authenticatorPool.set(driver.addVirtualAuthenticator(options));
     }
 
     public void destroyVirtualAuthenticator() {
+        var authenticator = authenticatorPool.get();
         if (authenticator == null) return;
 
-        var driver = Driver.get();
-        driver.removeVirtualAuthenticator(authenticator);
-        authenticator = null;
+        var driver = Driver.getDriver();
+        if (driver != null) {
+            driver.removeVirtualAuthenticator(authenticator);
+        }
+        authenticatorPool.remove();
     }
 
     public void putCredentialInAuthenticator(Credential credential) {
-        authenticator.addCredential(credential);
+        authenticatorPool.get().addCredential(credential);
     }
 
     public void enableUserVerification() {
-        authenticator.setUserVerified(true);
+        authenticatorPool.get().setUserVerified(true);
     }
 
     public void disableUserVerification() {
-        authenticator.setUserVerified(false);
+        authenticatorPool.get().setUserVerified(false);
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/AxeStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/AxeStepDef.java
@@ -21,10 +21,10 @@ public class AxeStepDef extends BasePage {
     public static void thereAreNoAccessibilityViolations() {
         //        System.out.println(ACCESSIBILITY_CHECKS);
         if (ACCESSIBILITY_CHECKS) {
-            System.out.println("Page in test = " + Driver.get().getTitle());
+            System.out.println("Page in test = " + Driver.getOrCreate().getTitle());
 
             JSONObject responseJSON =
-                    new AXE.Builder(Driver.get(), scriptUrl)
+                    new AXE.Builder(Driver.getOrCreate(), scriptUrl)
                             .options("{ runOnly: { type: 'tag', values: ['wcag2a','wcag21aa'] } }")
                             .analyze();
 

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
@@ -47,7 +47,7 @@ public class CommonStepDef extends BasePage {
 
     @Given("JavaScript is disabled")
     public void javaScriptIsDisabled() {
-        ChromeDriver driver = Driver.get();
+        ChromeDriver driver = Driver.getOrCreate();
         driver.executeCdpCommand(
                 "Emulation.setScriptExecutionDisabled", java.util.Map.of("value", true));
     }
@@ -111,7 +111,7 @@ public class CommonStepDef extends BasePage {
 
     @And("the user's cookies are cleared")
     public void theUsersCookiesAreCleared() {
-        Driver.get().manage().deleteAllCookies();
+        Driver.getOrCreate().manage().deleteAllCookies();
     }
 
     @Then("the user is shown an error message")
@@ -122,7 +122,7 @@ public class CommonStepDef extends BasePage {
     @Then("the user is not shown any error messages")
     public void theNewUserIsNotShownAnErrorMessage() {
         switchDefaultTimeout("off");
-        List<WebElement> errorFields = Driver.get().findElements(By.id("code-error"));
+        List<WebElement> errorFields = Driver.getOrCreate().findElements(By.id("code-error"));
         switchDefaultTimeout("on");
         if (!errorFields.isEmpty()) {
             System.out.println("setup-authenticator-app error: " + errorFields.get(0));
@@ -168,7 +168,7 @@ public class CommonStepDef extends BasePage {
 
     @Given("the user's session has ended")
     public void theUsersSessionHasEnded() {
-        Driver.get().manage().deleteAllCookies();
+        Driver.getOrCreate().manage().deleteAllCookies();
     }
 
     @When(
@@ -224,7 +224,7 @@ public class CommonStepDef extends BasePage {
 
     @Then("the {string} cookie has been set")
     public void theCookieHasBeenSet(String cookieName) {
-        var cookie = Driver.get().manage().getCookieNamed(cookieName);
+        var cookie = Driver.getOrCreate().manage().getCookieNamed(cookieName);
         assertNotNull(cookie);
     }
 
@@ -251,7 +251,7 @@ public class CommonStepDef extends BasePage {
 
     @And("the user info JSON is extracted from the stub page")
     public void extractUserInfoJsonFromStubPage() {
-        WebDriver driver = Driver.get();
+        WebDriver driver = Driver.getOrCreate();
         JavascriptExecutor js = (JavascriptExecutor) driver;
 
         String json;

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.*;
-import static uk.gov.di.test.utils.Driver.getDriver;
+import static uk.gov.di.test.utils.Driver.get;
 
 public class CommonStepDef extends BasePage {
     public CrossPageFlows crossPageFlows;
@@ -201,24 +201,25 @@ public class CommonStepDef extends BasePage {
     @Then("the user email is blocked and taken to {string} page")
     @Then("the URL is present with suffix {string}")
     public void theUrlIsPresentWithSuffix(String expectedSuffix) {
-        WebDriverWait wait = new WebDriverWait(getDriver(), Duration.ofSeconds(10));
+        var driver = get().orElseThrow();
+        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
         Boolean urlContainsSuffix =
                 wait.until(
-                        driver ->
-                                driver.getCurrentUrl() != null
-                                        && driver.getCurrentUrl().contains(expectedSuffix));
+                        d ->
+                                d.getCurrentUrl() != null
+                                        && d.getCurrentUrl().contains(expectedSuffix));
         assertTrue(
                 urlContainsSuffix,
                 "Expected URL to contain suffix: "
                         + expectedSuffix
                         + " but was: "
-                        + getDriver().getCurrentUrl());
+                        + driver.getCurrentUrl());
     }
 
     @And("the user navigates to the previous page")
     @And("the user attempt to navigates to the previous page")
     public void theUserNavigatesToThePreviousPage() {
-        WebDriver driver = getDriver();
+        WebDriver driver = get().orElseThrow();
         driver.navigate().back();
     }
 

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/Hooks.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/Hooks.java
@@ -47,7 +47,7 @@ public class Hooks extends BasePage {
 
     @After(value = "@UI", order = 3)
     public void deleteAllCookies() {
-        Driver.get().manage().deleteAllCookies();
+        Driver.getOrCreate().manage().deleteAllCookies();
     }
 
     @After(value = "@UI", order = 2)
@@ -58,7 +58,7 @@ public class Hooks extends BasePage {
     @After(value = "@UI", order = 1)
     public void takeScreenshotOnFailure(Scenario scenario) {
         if (scenario.isFailed()) {
-            WebDriver driver = Driver.get();
+            WebDriver driver = Driver.getOrCreate();
             final byte[] screenshot = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);
 
             scenario.attach(
@@ -91,7 +91,7 @@ public class Hooks extends BasePage {
                     world.userCredentials.getEmail());
             userLifecycleService.deleteUserCredentialsFromDynamodb(world.userCredentials);
         }
-        Driver.get().manage().deleteAllCookies();
+        Driver.getOrCreate().manage().deleteAllCookies();
         Driver.closeDriver();
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/LegalAndPolicyStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/LegalAndPolicyStepDef.java
@@ -21,7 +21,7 @@ public class LegalAndPolicyStepDef extends BasePage {
 
     @And("the user clicks link {string}")
     public void theUserClicksLink(String linkText) {
-        Driver.get().findElement(By.partialLinkText(linkText)).click();
+        Driver.getOrCreate().findElement(By.partialLinkText(linkText)).click();
     }
 
     @Then("the user is taken to the accessibility statement page")
@@ -46,12 +46,12 @@ public class LegalAndPolicyStepDef extends BasePage {
 
     private void waitForPageLoadThenValidate(SupportingPages page) {
         waitForPageLoad(page.getShortTitle());
-        assertEquals(page.getRoute(), URI.create(Driver.get().getCurrentUrl()).getPath());
+        assertEquals(page.getRoute(), URI.create(Driver.getOrCreate().getCurrentUrl()).getPath());
     }
 
     private void checkPageLoadThenGoBackToSignIn(SupportingPages page) {
         waitForPageLoadThenValidate(page);
-        Driver.get().navigate().back();
+        Driver.getOrCreate().navigate().back();
         waitForPageLoad("Create your GOV.UK One Login or sign in");
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/LockoutsStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/LockoutsStepDef.java
@@ -67,7 +67,7 @@ public class LockoutsStepDef extends BasePage {
 
     @Then("no lockout is triggered and the user remains on the {string} page")
     public void noLockoutIsTriggered(String pageTitle) {
-        assertTrue(Objects.requireNonNull(Driver.get().getTitle()).contains(pageTitle));
+        assertTrue(Objects.requireNonNull(Driver.getOrCreate().getTitle()).contains(pageTitle));
     }
 
     // Utility

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/LoginStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/LoginStepDef.java
@@ -174,21 +174,21 @@ public class LoginStepDef extends BasePage {
     public void theUserIsTakenToTheIdentityProviderWelshLoginPage() {
         assertEquals(
                 "Creu eich GOV.UK One Login neu fewngofnodi - GOV.UK One Login",
-                Driver.get().getTitle());
+                Driver.getOrCreate().getTitle());
     }
 
     @Then("the user is taken to the Welsh enter your email page")
     public void theUserIsTakenToTheWelshEnterYourEmailPage() {
         assertEquals(
                 "Rhowch eich cyfeiriad e-bost i fewngofnodi i’ch GOV.UK One Login - GOV.UK One Login",
-                Driver.get().getTitle());
+                Driver.getOrCreate().getTitle());
         Assertions.assertNotEquals("Continue", enterYourEmailAddressPage.continueButtonText());
         Assertions.assertNotEquals("Back", enterYourEmailAddressPage.backButtonText());
     }
 
     @Then("the user is prompted for their password in Welsh")
     public void theUserIsPromptedForTheirPasswordInWelsh() {
-        assertEquals("Rhowch eich cyfrinair - GOV.UK One Login", Driver.get().getTitle());
+        assertEquals("Rhowch eich cyfrinair - GOV.UK One Login", Driver.getOrCreate().getTitle());
     }
 
     @When("the user enters their email address in Welsh")

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/RpStubStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/RpStubStepDef.java
@@ -57,13 +57,13 @@ public class RpStubStepDef extends BasePage {
     @Then("the user is forcibly logged out")
     @Then("the logged-in User is forcibly logged out")
     public void theUserIsLoggedOut() {
-        new WebDriverWait(Driver.get(), DEFAULT_PAGE_LOAD_WAIT_TIME)
+        new WebDriverWait(Driver.getOrCreate(), DEFAULT_PAGE_LOAD_WAIT_TIME)
                 .until(
                         driver -> {
                             String url = driver.getCurrentUrl();
                             return url != null && url.contains("error=login_required");
                         });
         // Clear all cookies to ensure clean session for next user
-        Driver.get().manage().deleteAllCookies();
+        Driver.getOrCreate().manage().deleteAllCookies();
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/utils/BrowserTabs.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/utils/BrowserTabs.java
@@ -6,7 +6,7 @@ import java.util.ArrayList;
 
 public class BrowserTabs {
     public static void createNewTab() {
-        ((JavascriptExecutor) Driver.getDriver()).executeScript("window.open()");
+        ((JavascriptExecutor) Driver.get().orElseThrow()).executeScript("window.open()");
     }
 
     public static void switchToTabByOrdinalNumber(String ordinalNumber) {
@@ -19,7 +19,8 @@ public class BrowserTabs {
     }
 
     public static void switchToTabByIndex(int index) {
-        ArrayList<String> tabs = new ArrayList<>(Driver.getDriver().getWindowHandles());
-        Driver.getDriver().switchTo().window(tabs.get(index));
+        var driver = Driver.get().orElseThrow();
+        ArrayList<String> tabs = new ArrayList<>(driver.getWindowHandles());
+        driver.switchTo().window(tabs.get(index));
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/utils/Driver.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/utils/Driver.java
@@ -1,5 +1,6 @@
 package uk.gov.di.test.utils;
 
+import org.jspecify.annotations.NonNull;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 
@@ -15,8 +16,8 @@ public class Driver {
         return driverPool.get();
     }
 
-    public static ChromeDriver get() {
-
+    @NonNull
+    public static ChromeDriver getOrCreate() {
         if (driverPool.get() == null)
             synchronized (Driver.class) {
                 ChromeOptions chromeOptions = buildChromeOptions();

--- a/acceptance-tests/src/test/java/uk/gov/di/test/utils/Driver.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/utils/Driver.java
@@ -5,6 +5,7 @@ import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 
 import java.io.File;
+import java.util.Optional;
 
 public class Driver {
     protected static final Boolean SELENIUM_HEADLESS =
@@ -12,8 +13,9 @@ public class Driver {
     private static final InheritableThreadLocal<ChromeDriver> driverPool =
             new InheritableThreadLocal<>();
 
-    public static ChromeDriver getDriver() {
-        return driverPool.get();
+    @NonNull
+    public static Optional<ChromeDriver> get() {
+        return Optional.ofNullable(driverPool.get());
     }
 
     @NonNull


### PR DESCRIPTION
## What

### Main change
We were getting lots of errors when running the full test suite - complaints about not being able to find an authenticator that should exist, or trying to create one when one already exists.

That's because previously, we stored 'authenticator' as a private field in VirtualAuthenticatorLifecycleService. However, this meant that when multiple threads started (multiple tests running with multiple browsers/drivers), a single 'authenticator' reference was shared. This caused create/delete issues where the tests falsely thought that the authenticator did/didn't exist.

This change now stores an 'authenticatorPool' so that every thread gets its own authenticator, and they don't collide with each other.

### Also

Renamed the public methods in the Driver class to be more representative of what they do, and wrap them in some null/optional handling to make it easier to work with them around the place.

## How to review

1. Code Review
2. Run the suite locally