### PR TITLE
AUT-5524: Deprecate/fix AIS acceptance tests

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/SupportPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/SupportPage.java
@@ -8,7 +8,7 @@ public class SupportPage extends BasePage {
     By supportLink = By.xpath("//*[contains(text(), 'Support (opens in new tab)')]");
     By moreDetailsField = By.id("moreDetailDescription");
     By successMessage = By.cssSelector(".govuk-panel--confirmation");
-    By mfaSupportLinkText = By.cssSelector("form[id='form-tracking'] p:nth-child(2)");
+    By mfaSupportLinkText = By.cssSelector("div[class='govuk-details__text'] p:nth-child(2)");
     By mfaSupportLinkAppText =
             By.cssSelector("div[class='govuk-details__text'] p[class='govuk-body']");
 

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/account_interventions.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/account_interventions.feature
@@ -1,47 +1,6 @@
 @UI @AccountInterventions
 Feature: Account interventions
 
-  Scenario: Sms user cannot log in when they have a temporarily suspended account
-    Given a user with SMS MFA exists
-    And the user has a temporarily suspended intervention
-    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
-    And the user selects sign in
-    Then the user is taken to the "Enter your email" page
-    When the user enters their email address
-    Then the user is taken to the "Enter your password" page
-    When the user enters their password
-    Then the user is taken to the "Check your phone" page
-    When the user enters the six digit security code from their phone
-    Then the user is taken to the "Sorry, there is a problem" page
-
-  Scenario: Auth app user cannot log in when they have a temporarily suspended account
-    Given a user with App MFA exists
-    And the user has a temporarily suspended intervention
-    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
-    And the user selects sign in
-    Then the user is taken to the "Enter your email" page
-    When the user enters their email address
-    Then the user is taken to the "Enter your password" page
-    When the user enters their password
-    Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
-    When the user enters the security code from the auth app
-    Then the user is taken to the "Sorry, there is a problem" page
-
-  Scenario: Sms user with outdated terms and conditions cannot log in when they have a temporarily suspended account
-    Given a user with SMS MFA exists
-    And the user has a temporarily suspended intervention
-    And the user has not yet accepted the latest terms and conditions
-    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
-    And the user selects sign in
-    Then the user is taken to the "Enter your email" page
-    When the user enters their email address
-    Then the user is taken to the "Enter your password" page
-    When the user enters their password
-    Then the user is taken to the "Check your phone" page
-    When the user enters the six digit security code from their phone
-    Then the user is taken to the "We’ve updated our terms of use" page
-    When the user agrees to the updated terms and conditions
-    Then the user is taken to the "Sorry, there is a problem" page
 
   Scenario: Sms user cannot change their password when they have a temporarily suspended account
     Given a user with SMS MFA exists
@@ -335,30 +294,5 @@ Feature: Account interventions
     When the user enters the six digit security code from their email
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
-    And the user dismisses the passkey registration page if present
-    Then the user is returned to the service
-
-  Scenario: Auth app user can log in when their One Login account intervention has been removed
-    Given a user with App MFA exists
-    And the user has a temporarily suspended intervention
-    When the user comes from the stub relying party with option 2fa-on and is taken to the "Create your GOV.UK One Login or sign in" page
-    And the user selects sign in
-    Then the user is taken to the "Enter your email" page
-    When the user enters their email address
-    Then the user is taken to the "Enter your password" page
-    When the user enters their password
-    Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
-    When the user enters the security code from the auth app
-    Then the user is taken to the "Sorry, there is a problem" page
-
-    When the user's interventions have been removed
-    And the user comes from the stub relying party with option 2fa-on and is taken to the "Create your GOV.UK One Login or sign in" page
-    And the user selects sign in
-    Then the user is taken to the "Enter your email" page
-    When the user enters their email address
-    Then the user is taken to the "Enter your password" page
-    When the user enters their password
-    Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
-    When the user enters the security code from the auth app
     And the user dismisses the passkey registration page if present
     Then the user is returned to the service


### PR DESCRIPTION
## What

- Remove 4 scenarios that test temporarily suspended account
  interventions during normal login flow
- This behaviour is enforced by the orch callback handler, not
  authentication. As such, they can be removed
- Also removed tests checking a user with removed interventions
  can sign in again after; this is covered by existing integration
  tests
- Update mfaSupportLinkText CSS selector to target the
  govuk-details component instead of the form element
- The support text moved outside the form into a details
  disclosure widget

## How to review

1. Code Review
2. Deploy to dev, then run the related PRs through their respective pipelines and see the tests pass

## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/3477
https://github.com/govuk-one-login/authentication-api/pull/8520
