### PR TITLE
AUT-5530: suppress passkey setup prompt during mfa reset journey 

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,7 @@ This uses a local browser via Selenium rather than the Dockerised setup.
 Run the following commands to log in to your AWS account as an admin in the dev account
 
 ````bash
-export AWS_PROFILE=di-authentication-development-AdministratorAccessPermission
-source ./scripts/check_aws_creds.sh
+aws sso login --profile di-authentication-development-AdministratorAccessPermission
 ````
 
 You will need to re-run this when your AWS session expires or SSM parameters change.

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/mfa-reset/migrated-users/mfa-reset-migrated.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/mfa-reset/migrated-users/mfa-reset-migrated.feature
@@ -60,6 +60,5 @@ When the user adds the secret key on the screen to their auth app
 And the user enters the security code from the auth app
 Then the user is taken to the "You’ve changed how you get security codes" page
 When the user clicks the continue button
-And the user dismisses the passkey registration page if present
 Then the user is returned to the service
 And the User only has a default MFA of "AUTH_APP" and remains migrated

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/account_recovery.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/account_recovery.feature
@@ -22,7 +22,6 @@ Feature: Account recovery
     And the user enters the security code from the auth app
     Then the user is taken to the "You’ve changed how you get security codes" page
     And the user clicks the continue button
-    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
     And the user selects sign in
@@ -57,7 +56,6 @@ Feature: Account recovery
     When the user enters the six digit security code from their phone
     Then the user is taken to the "You’ve changed how you get security codes" page
     And the user clicks the continue button
-    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
     When the user selects sign in

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/international_phone_number.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/international_phone_number.feature
@@ -89,7 +89,6 @@ Feature: International phone numbers
       When the user enters the six digit security code from their phone
       Then the user is taken to the "You’ve changed how you get security codes" page
       When the user clicks the continue button
-      And the user dismisses the passkey registration page if present
       Then the user is returned to the service
 
   @InternationalSmsSendingEnabled
@@ -116,7 +115,6 @@ Feature: International phone numbers
       And the user enters the six digit security code from their phone
       Then the user is taken to the "You’ve changed how you get security codes" page
       When the user clicks the continue button
-      And the user dismisses the passkey registration page if present
       Then the user is returned to the service
 
   @InternationalSmsSendingEnabled
@@ -145,7 +143,6 @@ Feature: International phone numbers
       And the user enters the six digit security code from their phone
       Then the user is taken to the "You’ve changed how you get security codes" page
       When the user clicks the continue button
-      And the user dismisses the passkey registration page if present
       Then the user is returned to the service
 
   @InternationalSmsSendingEnabled
@@ -197,7 +194,6 @@ Feature: International phone numbers
       And the user enters the six digit security code from their phone
       Then the user is taken to the "You’ve changed how you get security codes" page
       When the user clicks the continue button
-      And the user dismisses the passkey registration page if present
       Then the user is returned to the service
 
     Scenario: User with international SMS MFA is indefinitely locked out when send limit already set

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/mfa_reset.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/mfa_reset.feature
@@ -1,7 +1,6 @@
 @UI
 
 Feature: The MFA reset process.
-  The test below covers jira ticket: AUT-4298, AUT-4051, AUT-3993, AUT-3825, AUT-3930, AUT-3931, AUT-3997
   Begins in Authentication, when a user initiates an MFA reset
   they are redirected to Identity to determine their verification status. Identity verifies
   whether the user is classified as authentication-only or identity-verified.
@@ -24,7 +23,6 @@ Feature: The MFA reset process.
     And the user enters the six digit security code from their phone
     Then the user is taken to the "You’ve changed how you get security codes" page
     When the user clicks the continue button
-    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
 
@@ -45,7 +43,6 @@ Feature: The MFA reset process.
     And the user enters the six digit security code from their phone
     Then the user is taken to the "You’ve changed how you get security codes" page
     When the user clicks the continue button
-    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
 # ************************* AUTH APP Section *************************
@@ -67,7 +64,6 @@ Feature: The MFA reset process.
     And the user enters the security code from the auth app
     Then the user is taken to the "You’ve changed how you get security codes" page
     When the user clicks the continue button
-    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
 
@@ -89,7 +85,6 @@ Feature: The MFA reset process.
     And the user enters the security code from the auth app
     Then the user is taken to the "You’ve changed how you get security codes" page
     When the user clicks the continue button
-    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
 # ************************* Negative tests when for unsuccessful IPV responses **********************
@@ -112,7 +107,8 @@ Feature: The MFA reset process.
     And the user clicks the continue button
     Then the user is taken to the "<Page>" page
     When the user enters the six digit code for "<Mfa Type>"
-    And the user dismisses the passkey registration page if present
+    Then the user is taken to the "Sign in faster with your face, fingerprint or passcode - GOV.UK One Login" page
+    When the user chooses to skip passkey registration
     Then the user is returned to the service
     Examples:
       | Mfa Type | Link Text                                     | IPV Response           | Page                                                            |
@@ -173,7 +169,8 @@ Feature: The MFA reset process.
     And the user clicks the continue button
     Then the user is taken to the "<Page>" page
     When the user enters the six digit code for "<Mfa Type>"
-    And the user dismisses the passkey registration page if present
+    Then the user is taken to the "Sign in faster with your face, fingerprint or passcode - GOV.UK One Login" page
+    When the user chooses to skip passkey registration
     Then the user is returned to the service
     Examples:
       | Mfa Type | Link Text                                     | IPV Response           | Page                                                            |
@@ -205,7 +202,8 @@ Feature: The MFA reset process.
     And the user clicks the continue button
     Then the user is taken to the "<Page>" page
     When the user enters the six digit code for "<Mfa Type>"
-    And the user dismisses the passkey registration page if present
+    Then the user is taken to the "Sign in faster with your face, fingerprint or passcode - GOV.UK One Login" page
+    When the user chooses to skip passkey registration
     Then the user is returned to the service
     Examples:
       | Mfa Type | Link Text                                     | IPV Response              | Page                                                            |
@@ -251,7 +249,6 @@ Feature: The MFA reset process.
     When the user enters the six digit security code from their phone
     Then the user is taken to the "You’ve changed how you get security codes" page
     And the user clicks the continue button
-    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
 
@@ -291,7 +288,6 @@ Feature: The MFA reset process.
     And the user enters the security code from the auth app
     Then the user is taken to the "You’ve changed how you get security codes" page
     When the user clicks the continue button
-    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
 

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/mfa_reset.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/mfa_reset.feature
@@ -107,8 +107,7 @@ Feature: The MFA reset process.
     And the user clicks the continue button
     Then the user is taken to the "<Page>" page
     When the user enters the six digit code for "<Mfa Type>"
-    Then the user is taken to the "Sign in faster with your face, fingerprint or passcode - GOV.UK One Login" page
-    When the user chooses to skip passkey registration
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     Examples:
       | Mfa Type | Link Text                                     | IPV Response           | Page                                                            |
@@ -169,8 +168,7 @@ Feature: The MFA reset process.
     And the user clicks the continue button
     Then the user is taken to the "<Page>" page
     When the user enters the six digit code for "<Mfa Type>"
-    Then the user is taken to the "Sign in faster with your face, fingerprint or passcode - GOV.UK One Login" page
-    When the user chooses to skip passkey registration
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     Examples:
       | Mfa Type | Link Text                                     | IPV Response           | Page                                                            |
@@ -202,8 +200,7 @@ Feature: The MFA reset process.
     And the user clicks the continue button
     Then the user is taken to the "<Page>" page
     When the user enters the six digit code for "<Mfa Type>"
-    Then the user is taken to the "Sign in faster with your face, fingerprint or passcode - GOV.UK One Login" page
-    When the user chooses to skip passkey registration
+    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     Examples:
       | Mfa Type | Link Text                                     | IPV Response              | Page                                                            |


### PR DESCRIPTION
## What

During the MFA reset journey, we shouldn't see the setup a passkey prompt. These tests were skipping this prompt if it came up instead of failing. For the successful MFA reset tests, I've removed those steps from the tests so if the setup prompt appears, the tests should fail.

However, if a user goes to MFA reset and then enters their correct MFA, they should still see the prompt

## How to review

1. Code review

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
