### PR TITLE
BAU: skip passkey registration step if present in AIS tests

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/account_interventions.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/account_interventions.feature
@@ -79,6 +79,7 @@ Feature: Account interventions
     When the user enters their password
     Then the user is taken to the "Check your phone" page
     When the user enters the six digit security code from their phone
+    And the user dismisses the passkey registration page if present
     Then the user is taken to the "Your GOV.UK One Login has been permanently locked" page
 
   Scenario: Auth app user cannot log in when they have a permanently locked account
@@ -92,6 +93,7 @@ Feature: Account interventions
     When the user enters their password
     Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
     When the user enters the security code from the auth app
+    And the user dismisses the passkey registration page if present
     Then the user is taken to the "Your GOV.UK One Login has been permanently locked" page
 
   Scenario: Auth app user with outdated terms and conditions cannot log in when they have a permanently locked account
@@ -106,6 +108,7 @@ Feature: Account interventions
     When the user enters their password
     Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
     When the user enters the security code from the auth app
+    And the user dismisses the passkey registration page if present
     Then the user is taken to the "We’ve updated our terms of use" page
     When the user agrees to the updated terms and conditions
     Then the user is taken to the "Your GOV.UK One Login has been permanently locked" page
@@ -121,6 +124,7 @@ Feature: Account interventions
     When the user enters their password
     Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
     When the user enters the security code from the auth app
+    And the user dismisses the passkey registration page if present
     Then the user is taken to the "Your GOV.UK One Login has been permanently locked" page
 
   Scenario: Sms user cannot change their password when they have a permanently locked account
@@ -228,6 +232,7 @@ Feature: Account interventions
     When the user enters their password
     Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
     When the user enters the security code from the auth app
+    And the user dismisses the passkey registration page if present
     Then the user is taken to the "You need to reset your password" page
     When the user clicks the continue button
     Then the user is taken to the "Check your email" page
@@ -286,6 +291,7 @@ Feature: Account interventions
     When the user enters their password
     Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
     When the user enters the security code from the auth app
+    And the user dismisses the passkey registration page if present
     Then the user is taken to the "We’ve updated our terms of use" page
     When the user agrees to the updated terms and conditions
     Then the user is taken to the "You need to reset your password" page


### PR DESCRIPTION
## What

- Tests are currently failing in dev as the logic to not show the passkeys registration screen in these scenarios has not been implemented yet
- Once implemented application-side, we should remove these then redundant steps, as we will with other scenarios
- 
## How to review

1. Code Review

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
