### PR TITLE
AUT-5331: Passkey registration prompt does not appear after password reset journey

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/login/using-back-up-mfa.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/login/using-back-up-mfa.feature
@@ -432,7 +432,6 @@ Feature: Login Using Back Up MFA
     And the user enters the security code from backup MFA auth app
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
-    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
   Scenario: User resets password using a Backup SMS MFA
@@ -461,7 +460,6 @@ Feature: Login Using Back Up MFA
     When the user enters the six digit security code from their phone
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
-    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
   Scenario: User with Auth App Default MFA requests too many OTPs when resetting their password with a Backup SMS MFA and lockout

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/account_interventions.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/account_interventions.feature
@@ -217,7 +217,6 @@ Feature: Account interventions
 #    Then the user is taken to the "Reset your password" page
 #    The test needs to stop here in Build, due to there being static data in the AIS stub the reset pw flag is not removed and so the correct path is not followed
 #    When the user enters valid new password and correctly retypes it
-#    And the user dismisses the passkey registration page if present
 #    Then the user is returned to the service
 #    And the user clicks logout
 
@@ -239,7 +238,6 @@ Feature: Account interventions
     When the user enters the six digit security code from their email
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
-    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
   Scenario: Auth app user with a password reset intervention on their account is able to use the I have forgotten my password link
@@ -257,7 +255,6 @@ Feature: Account interventions
     When the user enters the security code from the auth app
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
-    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
   Scenario: Sms user is forced to reset their password when they have a password reset intervention on their account and their existing password is on top 100k password list
@@ -276,7 +273,6 @@ Feature: Account interventions
     When the user enters the six digit security code from their phone
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
-    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
   Scenario: Auth app user with outdated terms and conditions cannot log in when they have a password reset intervention on their account
@@ -300,5 +296,4 @@ Feature: Account interventions
     When the user enters the six digit security code from their email
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
-    And the user dismisses the passkey registration page if present
     Then the user is returned to the service

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/enforce_100k_password_check.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/enforce_100k_password_check.feature
@@ -15,7 +15,6 @@ Feature: Enforce 100k password check
     When the user enters the six digit security code from their phone
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
-    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     And the user logs out
 
@@ -32,6 +31,5 @@ Feature: Enforce 100k password check
     When the user enters the security code from the auth app
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
-    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     And the user logs out

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/reset_password.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/reset_password.feature
@@ -17,7 +17,6 @@ Feature: Reset password
     When the user enters the six digit security code from their phone
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
-    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
   Scenario: An auth app user can successfully reset their password
@@ -36,5 +35,4 @@ Feature: Reset password
     When the user enters the security code from the auth app
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
-    And the user dismisses the passkey registration page if present
     Then the user is returned to the service


### PR DESCRIPTION
Remove the optional step to dismiss the passkey registration prompt on all password reset journeys. This is because we are now suppressing the prompt in these cases, as we do not want to overburden a user who has been on a more complex journeys with prompts.

Here we remove the optional step to dismiss the passkey registration page to ensure that this behaviour cannot regress in environments with the passkey feature flag turned on

## Related PRs

[This PR](https://github.com/govuk-one-login/authentication-frontend/pull/3484) is the associated behaviour change. The frontend PR can be merged first as the steps removed in this PR are optional in any case, so this test PR just prevents regression by ensuring we never hit the prompt step.
