### PR TITLE
BAU: Enable reauth tests in dev and build environments

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/reauthentication.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/reauthentication.feature
@@ -124,6 +124,7 @@ Feature: Reauthentication of user
     Then the user is returned to the service
 
 
+  @ReauthMultiTabLogout
   # Orchestration-dependent: the expected error page is determined by the orchestration
   # layer's handling of invalidated sessions (see ATO-2482).
   Scenario: Sms user verify that when re-authenticating in tab B and then logs out in a tab A they cannot complete the re-authenticate in tab B when they enter a valid email
@@ -140,6 +141,7 @@ Feature: Reauthentication of user
     Then the user is taken to the "Sorry, the page has expired" page
 
 
+  @ReauthMultiTabLogout
   # Orchestration-dependent: the expected error page is determined by the orchestration
   # layer's handling of invalidated sessions (see ATO-2482).
   Scenario: Sms user verify that when re-authenticating in tab B and logs out in a tab A they cannot complete the re-authenticate in tab B when they enter a valid password


### PR DESCRIPTION
## What

- Tag multi-tab logout scenarios with @ReauthLogout so they can be excluded independently from other reauth tests
- These scenarios require a full logout facilitated by orch which is only available in staging (using RP stub)
- The rest can run successfully in dev and build using the orch stub
- 
## How to review

1. Code Review
2. Deploy to dev and see tests pass alongside related PRs

## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/3508
https://github.com/govuk-one-login/authentication-api/pull/8554
