### PR TITLE
Revert "BAU: Bump selenium/standalone-chromium from 132.0 to 148.0"

### DIFF
--- a/.github/workflows/build-and-push-adhoc-tests.yaml
+++ b/.github/workflows/build-and-push-adhoc-tests.yaml
@@ -2,7 +2,7 @@ name: Build and push ad hoc acceptance tests
 
 env:
   AWS_REGION: eu-west-2
-  SELENIUM_BASE: selenium/standalone-chromium:148.0
+  SELENIUM_BASE: selenium/standalone-chromium:132.0
   AD_HOC_DEV_ECR_REPO: dev-ad-hoc-tests-adhoctestrunnerimagerepository-ghvdzd2cyr46
   GHA_DEV_ROLE: arn:aws:iam::975050272416:role/authentication-api-pipeline-GitHubActionsRole-eoW45BhwCqWg
 

--- a/.github/workflows/build-and-push-tests-SP-dev.yaml
+++ b/.github/workflows/build-and-push-tests-SP-dev.yaml
@@ -2,7 +2,7 @@ name: Build and Push to UI DEV account
 
 env:
   AWS_REGION: eu-west-2
-  SELENIUM_BASE: selenium/standalone-chromium:148.0
+  SELENIUM_BASE: selenium/standalone-chromium:132.0
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build-and-push-tests-SP.yaml
+++ b/.github/workflows/build-and-push-tests-SP.yaml
@@ -2,7 +2,7 @@ name: Build and Push Tests Secure Pipeline
 
 env:
   AWS_REGION: eu-west-2
-  SELENIUM_BASE: selenium/standalone-chromium:148.0
+  SELENIUM_BASE: selenium/standalone-chromium:132.0
 
 on:
   push:

--- a/.github/workflows/build-and-push-tests-dev.yaml
+++ b/.github/workflows/build-and-push-tests-dev.yaml
@@ -4,7 +4,7 @@ env:
   AWS_REGION: eu-west-2
   DEV_GHA_DEPLOYER_ROLE: arn:aws:iam::653994557586:role/dev-auth-deploy-pipeline-GitHubActionsRole-QrtGginNnjDD
   DEV_ACCEPTANCE_ECR_REPO: acceptance-test-dev-testrunnerimagerepository-yh8assqv55do
-  SELENIUM_BASE_CHROMIUM: selenium/standalone-chromium:148.0
+  SELENIUM_BASE_CHROMIUM: selenium/standalone-chromium:132.0
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build-and-push-tests.yaml
+++ b/.github/workflows/build-and-push-tests.yaml
@@ -2,7 +2,7 @@ name: Build and Push Acceptance Tests
 
 env:
   AWS_REGION: eu-west-2
-  SELENIUM_BASE: selenium/standalone-chromium:148.0
+  SELENIUM_BASE: selenium/standalone-chromium:132.0
 
 #Role to Assume is  dev-auth-deploy-pipeline githubaction Role
 #ECR repo is acceptance test ECR repo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG SELENIUM_BASE=selenium/standalone-chromium:148.0
+ARG SELENIUM_BASE=selenium/standalone-chromium:132.0
 FROM gradle:8-jdk17 AS builder
 
 WORKDIR /test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,9 @@ version: '3.8'
 
 services:
   selenium-chrome:
-    image: selenium/standalone-chromium@sha256:8c5a8629c96104c0d73df94c6437af9ab9059c4e16aa32e35b330b7d77defe0b
+    image: selenium/standalone-chrome@sha256:36784cc22ea01886ac226146be343afe7d984d9fc69436e52c2c0f8fd0dc0f55
+    #USE THESE VALUES IF YOU HAVE A MAC M1/M2/M3 (ARM) chip
+    #image: seleniarm/standalone-chromium:latest
     ports:
       - 4444:4444
     networks:


### PR DESCRIPTION
This reverts commit 6dd770ada5d6fb97da2d9ea7676b45ac698639f5.

We've had a lot of flakiness in the pipeline, suspect this commit
