### PR TITLE
Aut 5532 5533/suppress passkey prompt in no 2fa variants

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/login/using-back-up-mfa.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/login/using-back-up-mfa.feature
@@ -685,7 +685,6 @@ Feature: Login Using Back Up MFA
     When the user clicks the continue button
     Then the user is taken to the "Enter a security code to continue" page
     When the user enters the six digit security code from their phone
-    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
   Scenario: User with Auth App as Default MFA and SMS as backup MFA switches MFA in uplift journey
@@ -712,7 +711,6 @@ Feature: Login Using Back Up MFA
     When the user clicks the continue button
     Then the user is taken to the "Enter a security code to continue" page
     When the user enters the six digit security code from their phone
-    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
   Scenario: Sms user successfully reauthenticate with backup phone number

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/auth_app_2fa_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/auth_app_2fa_journey.feature
@@ -42,7 +42,6 @@ Feature: Authentication App Journeys
     When the user enters their email address
     Then the user is taken to the "Enter your password" page
     When the user enters their password
-    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
   Scenario: User signs in auth app without 2FA, then uplifts
@@ -53,7 +52,6 @@ Feature: Authentication App Journeys
     When the user enters their email address
     Then the user is taken to the "Enter your password" page
     When the user enters their password
-    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
     Then the user comes from the stub relying party with options: [2fa-on,authenticated-2] and is taken to the "Enter a security code to continue" page

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/existing_user_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/existing_user_journey.feature
@@ -47,7 +47,6 @@ Feature: Login Journey
     When the user enters their email address
     Then the user is taken to the "Enter your password" page
     When the user enters their password
-    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     When the user comes from the stub relying party with options: [2fa-on,authenticated-2] and is taken to the "Enter a security code to continue" page
     Then the user is taken to the "Enter a security code to continue" page

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/existing_user_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/existing_user_journey.feature
@@ -52,7 +52,6 @@ Feature: Login Journey
     When the user comes from the stub relying party with options: [2fa-on,authenticated-2] and is taken to the "Enter a security code to continue" page
     Then the user is taken to the "Enter a security code to continue" page
     When the user enters the six digit security code from their phone
-    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     And the user clicks logout
 

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/international_phone_number.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/international_phone_number.feature
@@ -103,7 +103,6 @@ Feature: International phone numbers
       When the user enters their email address
       Then the user is taken to the "Enter your password" page
       When the user enters their password
-      And the user dismisses the passkey registration page if present
       Then the user is returned to the service
       When the user comes from the stub relying party with options: [2fa-on,authenticated-2] and is taken to the "Enter a security code to continue" page
       When the user enters the six digit security code from their phone
@@ -222,7 +221,6 @@ Feature: International phone numbers
       When the user enters their email address
       Then the user is taken to the "Enter your password" page
       When the user enters their password
-      And the user dismisses the passkey registration page if present
       Then the user is returned to the service
       When the user comes from the stub relying party with options: [2fa-on,authenticated-2] and is taken to the "Enter a security code to continue" page
       When the user requests the phone otp code to the international numbers limit
@@ -239,7 +237,6 @@ Feature: International phone numbers
       When the user enters their email address
       Then the user is taken to the "Enter your password" page
       When the user enters their password
-      And the user dismisses the passkey registration page if present
       Then the user is returned to the service
       When the user comes from the stub relying party with options: [2fa-on,authenticated-2] and is taken to the "Sorry, there’s a problem" page
       When the user selects "Check if you can change how you get security codes" link
@@ -340,7 +337,6 @@ Feature: International phone numbers
       When the user enters their email address
       Then the user is taken to the "Enter your password" page
       When the user enters their password
-      And the user dismisses the passkey registration page if present
       Then the user is returned to the service
       When the user comes from the stub relying party with options: [2fa-on,authenticated-2] and is taken to the "Sorry, there’s a problem" page
       When the user selects "Check if you can change how you get security codes" link

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/mfa_reset.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/mfa_reset.feature
@@ -223,7 +223,6 @@ Feature: The MFA reset process.
     And the user enters the security code from the auth app
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
-    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     And the user clicks logout
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -263,7 +262,6 @@ Feature: The MFA reset process.
     When the user enters the six digit security code from their phone
     Then the user is taken to the "Reset your password" page
     When the user enters valid new password and correctly retypes it
-    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
     And the user clicks logout
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/reauthentication.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/reauthentication.feature
@@ -120,7 +120,6 @@ Feature: Reauthentication of user
     When the user enters an incorrect password 5 times
     And the user opens up new tab in the same browser, performs a silent log in and switches back to the first tab
     When the user enters an incorrect password 1 times
-    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
 
@@ -171,7 +170,6 @@ Feature: Reauthentication of user
     And the user enters the six digit security code from their phone
     And the user switches back to the second tab
     And the user enters their email address for reauth
-    And the user dismisses the passkey registration page if present
     Then the user is returned to the service
 
 


### PR DESCRIPTION
## What

Remove the optional step to dismiss the passkey registration prompt on 1fa and uplift journeys. This is because we are now suppressing the prompt in these cases.

Also removes the possibility of hitting the prompt on reauth journeys and some additional password reset journeys which were missed when doing this work previously.

Here we remove the optional step to dismiss the passkey registration page to ensure that this behaviour cannot regress in environments with the passkey feature flag turned on

## Related PRs

[Frontend PR](https://github.com/govuk-one-login/authentication-frontend/pull/3511) which implements this and needs to be merged first
[Backend PR](https://github.com/govuk-one-login/authentication-api/pull/8564) which adds an additional check to ensure only 2fa journeys can set up passkeys