### PR TITLE
Aut 5641: Add test for account intervention detected in amc during passkey create

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/BasePage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/BasePage.java
@@ -246,4 +246,9 @@ public class BasePage {
         findElement(By.xpath(String.format("//label[normalize-space(text())='%s']", textValue)))
                 .click();
     }
+
+    public void selectCheckboxWithText(String textValue) {
+        findElement(By.xpath(String.format("//label[normalize-space(text())='%s']", textValue)))
+                .click();
+    }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
@@ -192,6 +192,11 @@ public class CommonStepDef extends BasePage {
         selectRadioOptionWithText(value);
     }
 
+    @And("the {string} checkbox is selected")
+    public void checkboxIsSelected(String value) {
+        selectCheckboxWithText(value);
+    }
+
     @Then("User is taken to {string}")
     public void userIsTakenTo(String pageTitle) {
         waitForPageLoad(pageTitle);

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/passkeys.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/passkeys.feature
@@ -108,6 +108,28 @@ Feature: Passkeys
     And the user clicks the continue button
     Then the user is taken to the "Sign in faster with your face, fingerprint or passcode - GOV.UK One Login" page
 
+  @EnvironmentWithAMCStubDeployed @AccountInterventions
+  Scenario: Existing user with interventions added after they start the passkey create journey is redirected to relevant error screen even if they need to accept terms and conditions
+    Given a user with no passkey and SMS MFA exists
+    And the user has not yet accepted the latest terms and conditions
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
+    When the user enters their email address
+    Then the user is taken to the "Enter your password" page
+    When the user enters their password
+    Then the user is taken to the "Check your phone" page
+    When the user enters the six digit security code from their phone
+    Then the user is taken to the "Sign in faster with your face, fingerprint or passcode - GOV.UK One Login" page
+    When the user clicks the continue button
+    Then the user is taken to the AMC stub page passkey create page
+    When "Account Interventions Failure" radio option selected
+    And the "Reset password" checkbox is selected
+    And the "Suspended" checkbox is selected
+    And the user has a password reset intervention
+    And the user clicks the continue button
+    Then the user is taken to the "You need to reset your password" page
+
   @PasskeyUsageEnabled
   Scenario: Existing user with a passkey sign in
     Given a user exists with a passkey


### PR DESCRIPTION
When adding a passkey, it's possible that an account intervention will be added on a user after they leave auth (where we'll do an account interventions check), while they are in AMC.

This tests for this scenario, which we handle the same way as we do other interventions (taking to an error screen, or taking through a password reset journey).

This involves setting the intervention up in two ways in the test: firstly, setting the intervention up in the ais stub, which will control the behaviour on auth's side. Secondly, setting up the amc stub to return an interventions response. These are both needed since the flow in our app is: if we see an interventions response returned from amc, we bounce the user straight to auth code which performs another interventions check and responds accordingly. This is done to simplify the logic and not have to wire in another interventions journey directly from the passkey callback. This also means that for the purposes of the test, we also need to set up in the intervention in our stub database in order for the auth estate to see the intervention. In reality, both amc and auth will read from the same source (the ais api).

## Related PRs (these need to be merged first):

* [handling an account intervention response from amc on the frontend](https://github.com/govuk-one-login/authentication-frontend/pull/3532)
* [adding the ability to return an account intervention response from the amc stub](https://github.com/govuk-one-login/authentication-stubs/pull/776)