### PR TITLE
AUT-5050: Add tests for passkey prompt suppression after recent skip

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/passkeys.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/passkeys.feature
@@ -2,7 +2,7 @@
 Feature: Passkeys
 
 # Skip passkey create
-  Scenario: Existing user without a passkey can log in and skip passkey creation successfully
+  Scenario: Existing user without a passkey can log in and skip passkey creation successfully and is not subsequently prompted
     Given a user with no passkey and SMS MFA exists
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
     When the user selects sign in
@@ -14,6 +14,15 @@ Feature: Passkeys
     When the user enters the six digit security code from their phone
     Then the user is taken to the "Sign in faster with your face, fingerprint or passcode - GOV.UK One Login" page
     When the user chooses to skip passkey registration
+    Then the user is returned to the service
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
+    When the user enters their email address
+    Then the user is taken to the "Enter your password" page
+    When the user enters their password
+    Then the user is taken to the "Check your phone" page
+    When the user enters the six digit security code from their phone
     Then the user is returned to the service
 
   Scenario: Existing user with a new account and no passkey is not prompted to setup a passkey
@@ -69,7 +78,7 @@ Feature: Passkeys
     Then the user is returned to the service
 
   @EnvironmentWithAMCStubDeployed
-  Scenario: Existing user without a passkey is taken to updated terms and conditions if they click skip when creating a passkey
+  Scenario: Existing user without a passkey is taken to updated terms and conditions if they click skip when creating a passkey and not prompted on a subsequent journey
     Given a user with no passkey and SMS MFA exists
     And the user has not yet accepted the latest terms and conditions
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
@@ -87,6 +96,16 @@ Feature: Passkeys
     And the user clicks the continue button
     Then the user is taken to the "We’ve updated our terms of use" page
     When the user agrees to the updated terms and conditions
+    Then the user is returned to the service
+#    A subsequent journey where terms and conditions already accepted and no passkey prompt appears
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
+    When the user enters their email address
+    Then the user is taken to the "Enter your password" page
+    When the user enters their password
+    Then the user is taken to the "Check your phone" page
+    When the user enters the six digit security code from their phone
     Then the user is returned to the service
 
   @EnvironmentWithAMCStubDeployed


### PR DESCRIPTION
Amend existing tests to check that a user who has skipped passkey registration is not re-prompted on a subsequent journey
Amends the existing tests for skipping passkey regisration (in auth or amc) to check for a subsequent journey.

The duration of time for which the prompt is suppressed is different in staging (5 minutes) than build (1 week). To avoid building conditional logic, just do an immediate subsequent journey after the skip event, where the prompt should never appear.

## Related PRs:

[This backend PR](https://github.com/govuk-one-login/authentication-api/pull/8695) implements this logic, and should be merged before this PR.