### PR TITLE
 BAU: Improve dependabot grouping to separate major bumps from minor/patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,11 +14,14 @@ updates:
       - dependency-name: "gradle"
         versions: [ "[9.0,)" ]
     groups:
-      gradle-most-dependencies:
+      gradle-minor-and-patch:
         patterns:
           - "*"
         exclude-patterns:
           - "*selenium*"
+        update-types:
+          - "minor"
+          - "patch"
     target-branch: main
     commit-message:
       prefix: BAU
@@ -29,9 +32,12 @@ updates:
       cronjob: "0 3 1,15 * *"
     open-pull-requests-limit: 10
     groups:
-      gha-all-dependencies:
+      gha-minor-and-patch:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
     target-branch: main
     commit-message:
       prefix: BAU


### PR DESCRIPTION
Previously all gradle dependency updates were grouped into a single PR regardless of version bump type. This meant major version upgrades with potential breaking changes (e.g. rest-assured 5→6, gradle-wrapper 8→9) were bundled with safe patch updates, making PRs hard to review and risky to merge. Now only minor and patch updates are grouped together, while major version bumps each get their own PR for individual review.