### PR TITLE
AUT-5050: Log out of session before re-starting login

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/passkeys.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/ui/passkeys.feature
@@ -15,6 +15,7 @@ Feature: Passkeys
     Then the user is taken to the "Sign in faster with your face, fingerprint or passcode - GOV.UK One Login" page
     When the user chooses to skip passkey registration
     Then the user is returned to the service
+    And the user clicks logout
     When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
     When the user selects sign in
     Then the user is taken to the "Enter your email" page


### PR DESCRIPTION
## What

We had a bug in the tests where, on the second sign-in, the user was taken straight to User Info. That's because the previous session was still active, so a silent login was performed.

This change logs out the user after the first journey is completed, so the second journey can be performed normally.

## How to review

1. Code Review